### PR TITLE
Fill menu helper and resolver gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,12 @@ Composable menu builder and renderer for CakePHP applications.
 
 This branch is for **CakePHP 5.3+**. See the [version map](https://github.com/dereuromark/cakephp-menu/wiki#cakephp-version-map) for details.
 
-This plugin provides a small menu tree API with:
+Features:
 
-- nested menu items and submenus
-- string and Cake-style array URLs
-- alternate match routes, named routes, and fuzzy route matching
-- renderer abstraction with a Cake `StringTemplate` implementation
-- breadcrumb rendering and Cake `BreadcrumbsHelper` integration
-- request-aware active item resolution
-- callback and authorization resolvers for app-specific rules
-- named-menu Cake view helper integration
+- nested menu trees with string and Cake-style array URLs
+- active-state matching with alternate routes, named routes, and fuzzy matching
+- helper-managed named menus and breadcrumb integration
+- extensible resolvers and renderers for app-specific rules
 
 ## Installation
 
@@ -68,125 +64,6 @@ $account->add($menu->newItem('Profile', ['controller' => 'Users', 'action' => 'p
 $account->add($menu->newItem('Logout', ['controller' => 'Users', 'action' => 'logout']));
 
 echo $this->Menu->render($menu);
-```
-
-## Helper Workflow
-
-For view-driven menus you can let the helper manage named menus and active-state resolution:
-
-```php
-$menu = $this->Menu->create('main', [
-    'menuAttributes' => ['class' => 'nav'],
-]);
-$menu->addItem('Home', '/');
-$menu->addItem('Articles', ['controller' => 'Articles', 'action' => 'index'], [
-    'matchRoutes' => [
-        ['controller' => 'Articles', 'action' => 'view'],
-    ],
-    'fuzzy' => true,
-]);
-
-echo $this->Menu->render('main');
-```
-
-The helper also manages named menu lifecycle and breadcrumb generation:
-
-```php
-$menu = $this->Menu->getOrCreate('main');
-
-if (!$this->Menu->has('account')) {
-    $account = $menu->addItem('Account', '/account');
-    $account->getSubMenu()->addItem('Profile', '/account/profile');
-}
-
-echo $this->Menu->renderBreadcrumbs('main');
-```
-
-## Resolvers
-
-Resolvers let you decorate menu items after construction:
-
-- `Psr7UrlResolver`: marks string URL items active based on the current request URI
-- `UrlArrayResolver`: marks Cake array URL items active from request params, including fuzzy and named-route matching
-- `LoggedInResolver`: hides items marked with `auth = loggedIn|loggedOut`
-- `AuthorizationResolver`: hides or shows items via an app-provided authorization callback
-- `CallbackResolver`: generic resolver hook for section matching, metadata-driven visibility, or other custom rules
-- `ResolverCollection`: applies multiple resolvers in order
-
-Example:
-
-```php
-use Menu\Resolver\LoggedInResolver;
-use Menu\Resolver\ResolverCollection;
-use Menu\Resolver\UrlArrayResolver;
-
-$menu->addItem('Login', ['controller' => 'Users', 'action' => 'login'], [
-    'data' => ['auth' => 'loggedOut'],
-]);
-
-$menu->resolve(
-    (new ResolverCollection())
-        ->add(new UrlArrayResolver($this->request))
-        ->add(new LoggedInResolver($this->Authentication->getIdentity() !== null))
-);
-```
-
-Authorization example:
-
-```php
-use Menu\Item\ItemInterface;
-use Menu\Resolver\AuthorizationResolver;
-use Menu\Resolver\ResolverContext;
-
-$menu->resolve(new AuthorizationResolver(
-    static function (ItemInterface $item, ResolverContext $context): ?bool {
-        if ($item->getData('permission') === null) {
-            return null;
-        }
-
-        return $authorization->can($identity, (string)$item->getData('permission'));
-    }
-));
-```
-
-## Rendering
-
-The default renderer is `Menu\Renderer\StringTemplateRenderer`.
-
-It outputs nested `<ul>` / `<li>` markup and supports:
-
-- root menu attributes
-- item attributes
-- `before` / `after` inline markup
-- dividers
-- raw HTML items
-- active and active-ancestor CSS classes
-- first/last/branch/leaf/menu-level classes
-- `aria-current` and `aria-expanded` output
-- rendering the active item as text instead of a link
-
-The plugin also includes `Menu\Renderer\BreadcrumbRenderer` for rendering the active menu path as breadcrumb markup.
-
-You can override templates through helper options/config and limit automatic resolution depth via `resolveDepth`.
-
-## Breadcrumbs
-
-You can feed CakePHP's built-in `BreadcrumbsHelper` directly from the active menu path:
-
-```php
-$crumbs = $this->Menu->getBreadcrumbs('main');
-$this->Menu->populateBreadcrumbs('main');
-
-echo $this->Breadcrumbs->render();
-```
-
-Or render breadcrumbs in one step:
-
-```php
-echo $this->Menu->renderBreadcrumbs('main');
-echo $this->Menu->renderBreadcrumbs('main', [
-    'renderer' => \Menu\Renderer\BreadcrumbRenderer::class,
-]);
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ This plugin provides a small menu tree API with:
 
 - nested menu items and submenus
 - string and Cake-style array URLs
-- alternate match routes and fuzzy route matching
+- alternate match routes, named routes, and fuzzy route matching
 - renderer abstraction with a Cake `StringTemplate` implementation
+- breadcrumb rendering and Cake `BreadcrumbsHelper` integration
 - request-aware active item resolution
+- callback and authorization resolvers for app-specific rules
 - named-menu Cake view helper integration
 
 ## Installation
@@ -87,13 +89,28 @@ $menu->addItem('Articles', ['controller' => 'Articles', 'action' => 'index'], [
 echo $this->Menu->render('main');
 ```
 
+The helper also manages named menu lifecycle and breadcrumb generation:
+
+```php
+$menu = $this->Menu->getOrCreate('main');
+
+if (!$this->Menu->has('account')) {
+    $account = $menu->addItem('Account', '/account');
+    $account->getSubMenu()->addItem('Profile', '/account/profile');
+}
+
+echo $this->Menu->renderBreadcrumbs('main');
+```
+
 ## Resolvers
 
 Resolvers let you decorate menu items after construction:
 
 - `Psr7UrlResolver`: marks string URL items active based on the current request URI
-- `UrlArrayResolver`: marks Cake array URL items active from request params, including fuzzy route matching
+- `UrlArrayResolver`: marks Cake array URL items active from request params, including fuzzy and named-route matching
 - `LoggedInResolver`: hides items marked with `auth = loggedIn|loggedOut`
+- `AuthorizationResolver`: hides or shows items via an app-provided authorization callback
+- `CallbackResolver`: generic resolver hook for section matching, metadata-driven visibility, or other custom rules
 - `ResolverCollection`: applies multiple resolvers in order
 
 Example:
@@ -114,6 +131,24 @@ $menu->resolve(
 );
 ```
 
+Authorization example:
+
+```php
+use Menu\Item\ItemInterface;
+use Menu\Resolver\AuthorizationResolver;
+use Menu\Resolver\ResolverContext;
+
+$menu->resolve(new AuthorizationResolver(
+    static function (ItemInterface $item, ResolverContext $context): ?bool {
+        if ($item->getData('permission') === null) {
+            return null;
+        }
+
+        return $authorization->can($identity, (string)$item->getData('permission'));
+    }
+));
+```
+
 ## Rendering
 
 The default renderer is `Menu\Renderer\StringTemplateRenderer`.
@@ -127,9 +162,32 @@ It outputs nested `<ul>` / `<li>` markup and supports:
 - raw HTML items
 - active and active-ancestor CSS classes
 - first/last/branch/leaf/menu-level classes
+- `aria-current` and `aria-expanded` output
 - rendering the active item as text instead of a link
 
-You can override templates through helper options/config.
+The plugin also includes `Menu\Renderer\BreadcrumbRenderer` for rendering the active menu path as breadcrumb markup.
+
+You can override templates through helper options/config and limit automatic resolution depth via `resolveDepth`.
+
+## Breadcrumbs
+
+You can feed CakePHP's built-in `BreadcrumbsHelper` directly from the active menu path:
+
+```php
+$crumbs = $this->Menu->getBreadcrumbs('main');
+$this->Menu->populateBreadcrumbs('main');
+
+echo $this->Breadcrumbs->render();
+```
+
+Or render breadcrumbs in one step:
+
+```php
+echo $this->Menu->renderBreadcrumbs('main');
+echo $this->Menu->renderBreadcrumbs('main', [
+    'renderer' => \Menu\Renderer\BreadcrumbRenderer::class,
+]);
+```
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,15 @@ if ($this->Menu->has('main')) {
 $this->Menu->reset();
 ```
 
+You can also register menus lazily:
+
+```php
+$this->Menu->register('main', static function ($menu): void {
+    $menu->addItem('Home', '/');
+    $menu->addItem('Articles', '/articles');
+});
+```
+
 ## Item Options
 
 `Menu::addItem()` and `Menu::newItem()` accept these options:
@@ -67,6 +76,41 @@ $this->Menu->reset();
 - `fuzzy`: enables subset matching for Cake array routes
 - `raw`: render raw HTML inside the item
 - `divider`: render a divider item
+- `expanded`: runtime state for open branches
+
+## Import / Export
+
+Menu trees can be created from arrays and exported back:
+
+```php
+$menu = Menu::fromArray([
+    'attributes' => ['class' => 'nav'],
+    'items' => [
+        [
+            'id' => 'articles',
+            'label' => 'Articles',
+            'link' => '/articles',
+            'submenu' => [
+                'items' => [
+                    ['label' => 'View', 'link' => '/articles/view'],
+                ],
+            ],
+        ],
+    ],
+]);
+
+$data = $menu->toArray();
+```
+
+## Freeze Mode
+
+If you want to lock the structural definition after building it:
+
+```php
+$menu->freeze();
+```
+
+Frozen menus still allow runtime state updates from resolvers such as `active`, `visible`, and `expanded`, but block structural/content changes.
 
 ## Item Lookup and Mutation
 
@@ -106,6 +150,25 @@ It also supports named routes:
 
 ```php
 $menu->addItem('View', ['_name' => 'articles:view']);
+```
+
+### Section Resolver
+
+`SectionResolver` activates items from request parameter subsets:
+
+```php
+use Menu\Resolver\SectionResolver;
+
+$menu->addItem('Admin Articles', '/admin/articles', [
+    'data' => [
+        'section' => [
+            'prefix' => 'Admin',
+            'controller' => 'Articles',
+        ],
+    ],
+]);
+
+$menu->resolve(new SectionResolver($request));
 ```
 
 ### Login Visibility Resolver
@@ -150,6 +213,20 @@ $menu->resolve(new CallbackResolver(
         }
     }
 ));
+```
+
+### Permission Resolver
+
+For Authorization-style `can()` services there is also a convenience resolver:
+
+```php
+use Menu\Resolver\PermissionResolver;
+
+$menu->addItem('Admin', '/admin', [
+    'data' => ['permission' => 'admin.access'],
+]);
+
+$menu->resolve(new PermissionResolver($authorization, $identity));
 ```
 
 ### Multiple Resolvers
@@ -204,6 +281,25 @@ echo $this->Menu->renderBreadcrumbs('main', [
 ]);
 ```
 
+### Alternate Renderers
+
+JSON export:
+
+```php
+echo $this->Menu->render($menu, [
+    'renderer' => \Menu\Renderer\JsonRenderer::class,
+    'pretty' => true,
+]);
+```
+
+Bootstrap-flavored markup:
+
+```php
+echo $this->Menu->render($menu, [
+    'renderer' => \Menu\Renderer\Bootstrap5Renderer::class,
+]);
+```
+
 You can override templates per render call:
 
 ```php
@@ -221,3 +317,47 @@ echo $this->Menu->render($menu, [
 - String URLs and array URLs are both supported.
 - Active matching is automatic in the helper by default and uses both array and string resolvers.
 - The default renderer emits `aria-current="page"` for the active link and `aria-expanded` for branch items.
+
+## Recipes
+
+### Admin Sidebar
+
+```php
+$this->Menu->register('admin', static function ($menu): void {
+    $menu->addItem('Dashboard', ['prefix' => 'Admin', 'controller' => 'Dashboard', 'action' => 'index'], [
+        'data' => ['section' => ['prefix' => 'Admin', 'controller' => 'Dashboard']],
+    ]);
+    $menu->addItem('Articles', ['prefix' => 'Admin', 'controller' => 'Articles', 'action' => 'index'], [
+        'data' => ['section' => ['prefix' => 'Admin', 'controller' => 'Articles']],
+    ]);
+});
+
+echo $this->Menu->render('admin', [
+    'resolver' => (new \Menu\Resolver\ResolverCollection())
+        ->add(new \Menu\Resolver\SectionResolver($this->request)),
+]);
+```
+
+### Account Dropdown
+
+```php
+$account = $menu->addItem('Account', '#');
+$account->getSubMenu()->addItem('Profile', '/profile');
+$account->getSubMenu()->addItem('Logout', '/logout');
+
+echo $this->Menu->render($menu, [
+    'renderer' => \Menu\Renderer\Bootstrap5Renderer::class,
+]);
+```
+
+### Breadcrumbs From Navigation
+
+```php
+$this->Menu->register('main', static function ($menu): void {
+    $articles = $menu->addItem('Articles', '/articles');
+    $articles->getSubMenu()->addItem('View', '/articles/view/42');
+});
+
+echo $this->Menu->render('main');
+echo $this->Menu->renderBreadcrumbs('main');
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,18 @@ $menu->addItem('Home', '/');
 echo $this->Menu->render('main');
 ```
 
+The helper also supports lifecycle operations for named menus:
+
+```php
+$main = $this->Menu->getOrCreate('main');
+
+if ($this->Menu->has('main')) {
+    $this->Menu->remove('main');
+}
+
+$this->Menu->reset();
+```
+
 ## Item Options
 
 `Menu::addItem()` and `Menu::newItem()` accept these options:
@@ -50,6 +62,7 @@ echo $this->Menu->render('main');
 - `visible`: initial visibility
 - `active`: initial active state
 - `matchRoutes`: alternate string or Cake array routes used for active matching
+- `matchRoutes` also accepts named route arrays such as `['_name' => 'articles:view']`
 - `ignoreQueryString`: per-item override for string URL query matching
 - `fuzzy`: enables subset matching for Cake array routes
 - `raw`: render raw HTML inside the item
@@ -89,6 +102,12 @@ $menu->resolve(new UrlArrayResolver($request));
 
 can match requests with additional passed parameters such as `/articles/view/42` when the item uses `fuzzy => true`.
 
+It also supports named routes:
+
+```php
+$menu->addItem('View', ['_name' => 'articles:view']);
+```
+
 ### Login Visibility Resolver
 
 Mark items with metadata:
@@ -106,6 +125,33 @@ use Menu\Resolver\LoggedInResolver;
 $menu->resolve(new LoggedInResolver($identity !== null));
 ```
 
+### Authorization and Callback Resolvers
+
+```php
+use Menu\Item\ItemInterface;
+use Menu\Resolver\AuthorizationResolver;
+use Menu\Resolver\CallbackResolver;
+use Menu\Resolver\ResolverContext;
+
+$menu->resolve(new AuthorizationResolver(
+    static function (ItemInterface $item, ResolverContext $context): ?bool {
+        if ($item->getData('permission') === null) {
+            return null;
+        }
+
+        return $authorization->can($identity, (string)$item->getData('permission'));
+    }
+));
+
+$menu->resolve(new CallbackResolver(
+    static function (ItemInterface $item, ResolverContext $context): void {
+        if ($context->getDepth() > 1) {
+            $item->setExpanded();
+        }
+    }
+));
+```
+
 ### Multiple Resolvers
 
 ```php
@@ -116,6 +162,16 @@ $menu->resolve(
         ->add(new UrlArrayResolver($request))
         ->add(new LoggedInResolver($identity !== null))
 );
+```
+
+### Depth-Limited Resolution
+
+When rendering through the helper, you can limit how deep automatic URL resolution should scan:
+
+```php
+echo $this->Menu->render('main', [
+    'resolveDepth' => 1,
+]);
 ```
 
 ## Helper Rendering
@@ -129,6 +185,23 @@ You can also fetch the resolved active item and extract its path:
 ```php
 $current = $this->Menu->getCurrentItem('main');
 $path = $current ? $this->Menu->extractPath($current) : [];
+```
+
+### Breadcrumb Integration
+
+```php
+$crumbs = $this->Menu->getBreadcrumbs('main');
+$this->Menu->populateBreadcrumbs('main');
+
+echo $this->Breadcrumbs->render();
+```
+
+Or use the built-in breadcrumb renderer:
+
+```php
+echo $this->Menu->renderBreadcrumbs('main', [
+    'renderer' => \Menu\Renderer\BreadcrumbRenderer::class,
+]);
 ```
 
 You can override templates per render call:
@@ -147,3 +220,4 @@ echo $this->Menu->render($menu, [
 - `before`, `after`, and `raw` are treated as trusted markup.
 - String URLs and array URLs are both supported.
 - Active matching is automatic in the helper by default and uses both array and string resolvers.
+- The default renderer emits `aria-current="page"` for the active link and `aria-expanded` for branch items.

--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Item;
 
 use Cake\Utility\Text;
+use LogicException;
 use Menu\Link\Link;
 use Menu\Link\LinkInterface;
 use Menu\Menu;
@@ -15,6 +16,8 @@ class Item implements ItemInterface
     protected string $id;
 
     protected string $key = '';
+
+    protected bool $explicitKey = false;
 
     protected ?string $label = null;
 
@@ -59,6 +62,8 @@ class Item implements ItemInterface
 
     protected bool $expanded = false;
 
+    protected bool $frozen = false;
+
     /**
      * @phpstan-param \Menu\Link\LinkInterface|array<string|int, mixed>|string|null $link
      */
@@ -77,6 +82,7 @@ class Item implements ItemInterface
 
     public function setId(string $id): static
     {
+        $this->assertMutable();
         $this->id = $id;
 
         return $this;
@@ -89,7 +95,9 @@ class Item implements ItemInterface
 
     public function setKey(string $key): static
     {
+        $this->assertMutable();
         $this->key = $key;
+        $this->explicitKey = true;
 
         return $this;
     }
@@ -103,8 +111,14 @@ class Item implements ItemInterface
         return $this->key;
     }
 
+    public function hasExplicitKey(): bool
+    {
+        return $this->explicitKey;
+    }
+
     public function setLabel(string $label, bool $escape = true): static
     {
+        $this->assertMutable();
         $this->label = $label;
         $this->escapeLabel = $escape;
 
@@ -126,6 +140,7 @@ class Item implements ItemInterface
      */
     public function setLink(LinkInterface|string|array|null $link): static
     {
+        $this->assertMutable();
         if (!$link instanceof LinkInterface) {
             $link = Link::create($link);
         }
@@ -142,6 +157,7 @@ class Item implements ItemInterface
 
     public function setRaw(string $content): static
     {
+        $this->assertMutable();
         $this->raw = $content;
 
         return $this;
@@ -159,6 +175,7 @@ class Item implements ItemInterface
 
     public function setDivider(bool $divider = true): static
     {
+        $this->assertMutable();
         $this->divider = $divider;
 
         return $this;
@@ -195,6 +212,7 @@ class Item implements ItemInterface
 
     public function add(ItemInterface $item): static
     {
+        $this->assertMutable();
         $item->setParent($this);
         $this->getSubMenu()->add($item);
 
@@ -203,6 +221,7 @@ class Item implements ItemInterface
 
     public function setSubMenu(MenuInterface $menu): static
     {
+        $this->assertMutable();
         if ($menu instanceof Menu) {
             $menu->setOwnerItem($this);
         }
@@ -227,6 +246,7 @@ class Item implements ItemInterface
 
     public function setParent(ItemInterface $item): static
     {
+        $this->assertMutable();
         $this->parent = $item;
 
         return $this;
@@ -249,6 +269,7 @@ class Item implements ItemInterface
 
     public function setBefore(string $before): static
     {
+        $this->assertMutable();
         $this->before = $before;
 
         return $this;
@@ -261,6 +282,7 @@ class Item implements ItemInterface
 
     public function setAfter(string $after): static
     {
+        $this->assertMutable();
         $this->after = $after;
 
         return $this;
@@ -273,6 +295,7 @@ class Item implements ItemInterface
 
     public function setAttribute(string $name, mixed $value): static
     {
+        $this->assertMutable();
         $this->attributes[$name] = $value;
 
         return $this;
@@ -283,6 +306,7 @@ class Item implements ItemInterface
      */
     public function setAttributes(array $attributes, bool $merge = false): static
     {
+        $this->assertMutable();
         $this->attributes = $merge ? $attributes + $this->attributes : $attributes;
 
         return $this;
@@ -298,6 +322,7 @@ class Item implements ItemInterface
 
     public function setData(string $name, mixed $value): static
     {
+        $this->assertMutable();
         $this->data[$name] = $value;
 
         return $this;
@@ -317,6 +342,7 @@ class Item implements ItemInterface
      */
     public function setMatchRoutes(array $routes): static
     {
+        $this->assertMutable();
         $this->matchRoutes = [];
         foreach ($routes as $route) {
             $this->addMatchRoute($route);
@@ -330,6 +356,7 @@ class Item implements ItemInterface
      */
     public function addMatchRoute(string|array $route): static
     {
+        $this->assertMutable();
         $this->matchRoutes[] = $route;
 
         return $this;
@@ -345,6 +372,7 @@ class Item implements ItemInterface
 
     public function setIgnoreQueryString(?bool $ignoreQueryString): static
     {
+        $this->assertMutable();
         $this->ignoreQueryString = $ignoreQueryString;
 
         return $this;
@@ -357,6 +385,7 @@ class Item implements ItemInterface
 
     public function setFuzzyMatch(bool $fuzzyMatch = true): static
     {
+        $this->assertMutable();
         $this->fuzzyMatch = $fuzzyMatch;
 
         return $this;
@@ -377,5 +406,53 @@ class Item implements ItemInterface
     public function isExpanded(): bool
     {
         return $this->expanded;
+    }
+
+    public function freeze(): static
+    {
+        $this->frozen = true;
+        if ($this->subMenu instanceof MenuInterface) {
+            $this->subMenu->freeze();
+        }
+
+        return $this;
+    }
+
+    public function isFrozen(): bool
+    {
+        return $this->frozen;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'key' => $this->key !== '' ? $this->key : null,
+            'label' => $this->label,
+            'escape' => $this->escapeLabel,
+            'link' => $this->link?->getRawUrl(),
+            'linkAttributes' => $this->link?->getAttributes() ?? [],
+            'external' => $this->link?->isExternal() ?? false,
+            'raw' => $this->raw,
+            'divider' => $this->divider,
+            'visible' => $this->visible,
+            'active' => $this->active,
+            'expanded' => $this->expanded,
+            'before' => $this->before,
+            'after' => $this->after,
+            'attributes' => $this->attributes,
+            'data' => $this->data,
+            'matchRoutes' => $this->matchRoutes,
+            'ignoreQueryString' => $this->ignoreQueryString,
+            'fuzzy' => $this->fuzzyMatch,
+            'submenu' => $this->subMenu?->toArray(),
+        ];
+    }
+
+    protected function assertMutable(): void
+    {
+        if ($this->frozen) {
+            throw new LogicException('Cannot mutate a frozen menu item.');
+        }
     }
 }

--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -57,6 +57,8 @@ class Item implements ItemInterface
 
     protected bool $fuzzyMatch = false;
 
+    protected bool $expanded = false;
+
     /**
      * @phpstan-param \Menu\Link\LinkInterface|array<string|int, mixed>|string|null $link
      */
@@ -363,5 +365,17 @@ class Item implements ItemInterface
     public function isFuzzyMatch(): bool
     {
         return $this->fuzzyMatch;
+    }
+
+    public function setExpanded(bool $expanded = true): static
+    {
+        $this->expanded = $expanded;
+
+        return $this;
+    }
+
+    public function isExpanded(): bool
+    {
+        return $this->expanded;
     }
 }

--- a/src/Item/ItemInterface.php
+++ b/src/Item/ItemInterface.php
@@ -17,6 +17,8 @@ interface ItemInterface
 
     public function getKey(): string;
 
+    public function hasExplicitKey(): bool;
+
     public function setLabel(string $label, bool $escape = true): static;
 
     public function getLabel(): ?string;
@@ -114,4 +116,13 @@ interface ItemInterface
     public function setExpanded(bool $expanded = true): static;
 
     public function isExpanded(): bool;
+
+    public function freeze(): static;
+
+    public function isFrozen(): bool;
+
+    /**
+     * @phpstan-return array<string, mixed>
+     */
+    public function toArray(): array;
 }

--- a/src/Item/ItemInterface.php
+++ b/src/Item/ItemInterface.php
@@ -110,4 +110,8 @@ interface ItemInterface
     public function setFuzzyMatch(bool $fuzzyMatch = true): static;
 
     public function isFuzzyMatch(): bool;
+
+    public function setExpanded(bool $expanded = true): static;
+
+    public function isExpanded(): bool;
 }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Menu;
 
 use InvalidArgumentException;
+use LogicException;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
+use Menu\Link\Link;
 use Menu\Link\LinkInterface;
 use Menu\Resolver\ContextAwareResolverInterface;
 use Menu\Resolver\ResolverCollectionInterface;
@@ -37,6 +39,8 @@ class Menu implements MenuInterface
 
     protected ?ItemInterface $ownerItem = null;
 
+    protected bool $frozen = false;
+
     /**
      * @phpstan-param array<string, mixed> $attributes
      */
@@ -50,8 +54,66 @@ class Menu implements MenuInterface
         return $menu;
     }
 
+    public static function fromArray(array $config): static
+    {
+        $menu = static::create((array)($config['attributes'] ?? []));
+        foreach ((array)($config['data'] ?? []) as $name => $value) {
+            $menu->setData((string)$name, $value);
+        }
+
+        foreach ((array)($config['items'] ?? []) as $itemConfig) {
+            if (!is_array($itemConfig)) {
+                continue;
+            }
+
+            $item = $menu->newItem(
+                $itemConfig['label'] ?? null,
+                $itemConfig['link'] ?? null,
+                [
+                    'id' => $itemConfig['id'] ?? null,
+                    'key' => $itemConfig['key'] ?? null,
+                    'escape' => $itemConfig['escape'] ?? true,
+                    'before' => $itemConfig['before'] ?? null,
+                    'after' => $itemConfig['after'] ?? null,
+                    'attributes' => $itemConfig['attributes'] ?? [],
+                    'data' => $itemConfig['data'] ?? [],
+                    'visible' => $itemConfig['visible'] ?? true,
+                    'active' => $itemConfig['active'] ?? false,
+                    'raw' => $itemConfig['raw'] ?? null,
+                    'divider' => $itemConfig['divider'] ?? false,
+                    'submenuAttributes' => $itemConfig['submenu']['attributes'] ?? [],
+                    'matchRoutes' => $itemConfig['matchRoutes'] ?? [],
+                    'ignoreQueryString' => $itemConfig['ignoreQueryString'] ?? null,
+                    'fuzzy' => $itemConfig['fuzzy'] ?? false,
+                ],
+            );
+
+            if (!empty($itemConfig['linkAttributes']) && $item->getLink() !== null) {
+                $item->getLink()->setAttributes((array)$itemConfig['linkAttributes']);
+            }
+            if (!empty($itemConfig['external']) && $item->getLink() !== null) {
+                $item->setLink(Link::create(
+                    $item->getLink()->getRawUrl(),
+                    (array)$itemConfig['linkAttributes'],
+                    true,
+                ));
+            }
+            if (!empty($itemConfig['expanded'])) {
+                $item->setExpanded();
+            }
+            if (!empty($itemConfig['submenu']['items'])) {
+                $item->setSubMenu(static::fromArray((array)$itemConfig['submenu']));
+            }
+
+            $menu->add($item);
+        }
+
+        return $menu;
+    }
+
     public function add(ItemInterface $item): static
     {
+        $this->assertMutable();
         if ($this->ownerItem !== null && !$item->hasParent()) {
             $item->setParent($this->ownerItem);
         }
@@ -177,6 +239,7 @@ class Menu implements MenuInterface
      */
     public function setItems(array $items): static
     {
+        $this->assertMutable();
         $validatedItems = [];
         foreach ($items as $item) {
             if (!$item instanceof ItemInterface) {
@@ -215,6 +278,7 @@ class Menu implements MenuInterface
 
     public function remove(string $id): static
     {
+        $this->assertMutable();
         $items = [];
         foreach ($this->items as $item) {
             if ($item->getId() === $id) {
@@ -262,6 +326,7 @@ class Menu implements MenuInterface
 
     public function setData(string $name, mixed $value): static
     {
+        $this->assertMutable();
         $this->data[$name] = $value;
 
         return $this;
@@ -286,6 +351,7 @@ class Menu implements MenuInterface
 
     public function setAttribute(string $name, mixed $value): static
     {
+        $this->assertMutable();
         $this->attributes[$name] = $value;
 
         return $this;
@@ -296,6 +362,7 @@ class Menu implements MenuInterface
      */
     public function setAttributes(array $attributes, bool $merge = false): static
     {
+        $this->assertMutable();
         $this->attributes = $merge ? $attributes + $this->attributes : $attributes;
 
         return $this;
@@ -303,6 +370,7 @@ class Menu implements MenuInterface
 
     public function filter(callable $callback): static
     {
+        $this->assertMutable();
         $items = [];
         foreach ($this->items as $item) {
             if ($item->hasSubMenu()) {
@@ -320,6 +388,7 @@ class Menu implements MenuInterface
 
     public function sortBy(callable|string $by, string $direction = self::SORT_ASC): static
     {
+        $this->assertMutable();
         usort($this->items, function (ItemInterface $left, ItemInterface $right) use ($by, $direction): int {
             $leftValue = $this->extractSortValue($left, $by);
             $rightValue = $this->extractSortValue($right, $by);
@@ -388,9 +457,37 @@ class Menu implements MenuInterface
 
     public function setOwnerItem(ItemInterface $ownerItem): static
     {
+        $this->assertMutable();
         $this->ownerItem = $ownerItem;
 
         return $this;
+    }
+
+    public function freeze(): static
+    {
+        $this->frozen = true;
+        foreach ($this->items as $item) {
+            $item->freeze();
+        }
+
+        return $this;
+    }
+
+    public function isFrozen(): bool
+    {
+        return $this->frozen;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'attributes' => $this->attributes,
+            'data' => $this->data,
+            'items' => array_map(
+                static fn (ItemInterface $item): array => $item->toArray(),
+                $this->items,
+            ),
+        ];
     }
 
     protected function extractSortValue(ItemInterface $item, callable|string $by): mixed
@@ -431,10 +528,25 @@ class Menu implements MenuInterface
         }
         $ids[$id] = true;
 
+        if ($item->hasExplicitKey()) {
+            $keyId = '__key__' . $item->getKey();
+            if (isset($ids[$keyId])) {
+                throw new InvalidArgumentException(sprintf('Duplicate explicit menu item key `%s` detected.', $item->getKey()));
+            }
+            $ids[$keyId] = true;
+        }
+
         if ($item->hasSubMenu()) {
             foreach ($item->getSubMenu()->getItems() as $child) {
                 $this->collectIdentifiers($child, $ids);
             }
+        }
+    }
+
+    protected function assertMutable(): void
+    {
+        if ($this->frozen) {
+            throw new LogicException('Cannot mutate a frozen menu.');
         }
     }
 }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -8,7 +8,9 @@ use InvalidArgumentException;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
 use Menu\Link\LinkInterface;
+use Menu\Resolver\ContextAwareResolverInterface;
 use Menu\Resolver\ResolverCollectionInterface;
+use Menu\Resolver\ResolverContext;
 use Menu\Resolver\ResolverInterface;
 
 class Menu implements MenuInterface
@@ -54,6 +56,7 @@ class Menu implements MenuInterface
             $item->setParent($this->ownerItem);
         }
 
+        $this->assertUniqueItemTree($item);
         $this->items[] = $item;
 
         return $this;
@@ -182,6 +185,7 @@ class Menu implements MenuInterface
             $validatedItems[] = $item;
         }
 
+        $this->assertUniqueItems($validatedItems);
         $this->items = $validatedItems;
 
         return $this;
@@ -336,14 +340,50 @@ class Menu implements MenuInterface
 
     public function resolve(ResolverInterface|ResolverCollectionInterface $resolver): static
     {
-        foreach ($this->items as $item) {
-            $resolver->resolve($item);
-            if ($item->hasSubMenu()) {
-                $item->getSubMenu()->resolve($resolver);
-            }
-        }
+        $this->resolveItems($resolver, $this->items, 1, $this->ownerItem);
 
         return $this;
+    }
+
+    /**
+     * @param \Menu\Resolver\ResolverInterface|\Menu\Resolver\ResolverCollectionInterface $resolver
+     * @param list<\Menu\Item\ItemInterface> $items
+     * @param \Menu\Item\ItemInterface|null $parent
+     * @param int $depth
+     */
+    protected function resolveItems(
+        ResolverInterface|ResolverCollectionInterface $resolver,
+        array $items,
+        int $depth,
+        ?ItemInterface $parent,
+    ): void {
+        $context = new ResolverContext($depth, $parent);
+        foreach ($items as $item) {
+            if ($resolver instanceof ContextAwareResolverInterface) {
+                $resolver->resolveWithContext($item, $context);
+            } else {
+                $resolver->resolve($item);
+            }
+            if ($item->hasSubMenu()) {
+                $subMenu = $item->getSubMenu();
+                if ($subMenu instanceof self) {
+                    $subMenu->resolveItems($resolver, $subMenu->getItems(), $depth + 1, $item);
+                } else {
+                    $subMenu->resolve($resolver);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param list<\Menu\Item\ItemInterface> $items
+     */
+    protected function assertUniqueItems(array $items): void
+    {
+        $ids = [];
+        foreach ($items as $item) {
+            $this->collectIdentifiers($item, $ids);
+        }
     }
 
     public function setOwnerItem(ItemInterface $ownerItem): static
@@ -365,5 +405,36 @@ class Menu implements MenuInterface
             'label' => $item->getLabel(),
             default => $item->getData($by),
         };
+    }
+
+    protected function assertUniqueItemTree(ItemInterface $candidate): void
+    {
+        $ids = [];
+        foreach ($this->items as $item) {
+            $this->collectIdentifiers($item, $ids);
+        }
+
+        $this->collectIdentifiers($candidate, $ids);
+    }
+
+    /**
+     * @param \Menu\Item\ItemInterface $item
+     * @param array<string, true> $ids
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function collectIdentifiers(ItemInterface $item, array &$ids): void
+    {
+        $id = $item->getId();
+        if (isset($ids[$id])) {
+            throw new InvalidArgumentException(sprintf('Duplicate menu item id `%s` detected.', $id));
+        }
+        $ids[$id] = true;
+
+        if ($item->hasSubMenu()) {
+            foreach ($item->getSubMenu()->getItems() as $child) {
+                $this->collectIdentifiers($child, $ids);
+            }
+        }
     }
 }

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -26,6 +26,11 @@ interface MenuInterface
      */
     public static function create(array $attributes = []): static;
 
+    /**
+     * @phpstan-param array<string, mixed> $config
+     */
+    public static function fromArray(array $config): static;
+
     public function add(ItemInterface $item): static;
 
     /**
@@ -101,4 +106,13 @@ interface MenuInterface
     public function sortBy(callable|string $by, string $direction = self::SORT_ASC): static;
 
     public function resolve(ResolverInterface|ResolverCollectionInterface $resolver): static;
+
+    public function freeze(): static;
+
+    public function isFrozen(): bool;
+
+    /**
+     * @phpstan-return array<string, mixed>
+     */
+    public function toArray(): array;
 }

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Renderer;
+
+class Bootstrap5Renderer extends StringTemplateRenderer
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $_defaultConfig = [
+        'activeClass' => 'active',
+        'ancestorClass' => 'active',
+        'branchClass' => 'dropdown',
+        'submenuClass' => 'dropdown',
+        'nestedMenuClass' => 'dropdown-menu',
+        'menuLevelClass' => null,
+        'firstClass' => null,
+        'lastClass' => null,
+        'currentAsLink' => true,
+        'templates' => [
+            'menuWrapper' => '<ul{{attributes}}>{{items}}</ul>',
+            'item' => '<li{{attributes}}>{{content}}</li>',
+            'link' => '<a{{attributes}}>{{title}}</a>',
+            'label' => '<span{{attributes}}>{{title}}</span>',
+            'divider' => '<li{{attributes}}><hr class="dropdown-divider"></li>',
+        ],
+    ];
+}

--- a/src/Renderer/BreadcrumbRenderer.php
+++ b/src/Renderer/BreadcrumbRenderer.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Renderer;
+
+use Menu\Item\ItemInterface;
+use Menu\MenuInterface;
+use function implode;
+
+class BreadcrumbRenderer extends StringTemplateRenderer
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $_defaultConfig = [
+        'activeClass' => 'active',
+        'itemClass' => 'breadcrumb-item',
+        'menuClass' => 'breadcrumb',
+        'ariaLabel' => 'breadcrumb',
+        'templates' => [
+            'menuWrapper' => '<nav aria-label="{{ariaLabel}}"><ol{{attributes}}>{{items}}</ol></nav>',
+            'item' => '<li{{attributes}}>{{content}}</li>',
+            'link' => '<a{{attributes}}>{{title}}</a>',
+            'label' => '<span{{attributes}}>{{title}}</span>',
+        ],
+    ];
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function render(MenuInterface $menu, array $options = []): string
+    {
+        if (isset($options['templates']) && is_array($options['templates'])) {
+            $this->setConfig('templates', $options['templates'] + $this->getConfig('templates'));
+        }
+
+        $path = $options['path'] ?? null;
+        if (!is_array($path)) {
+            $activeItem = $menu->getActiveItem();
+            if ($activeItem === null) {
+                return '';
+            }
+
+            $path = [];
+            while ($activeItem !== null) {
+                $path[] = $activeItem;
+                $activeItem = $activeItem->getParent();
+            }
+            $path = array_reverse($path);
+        }
+
+        $items = [];
+        $count = count($path);
+        foreach ($path as $index => $item) {
+            if (!$item instanceof ItemInterface) {
+                continue;
+            }
+
+            $items[] = $this->renderBreadcrumbItem($item, $options, $index === $count - 1);
+        }
+
+        $attributes = $this->appendClass([], (string)($options['menuClass'] ?? $this->getConfig('menuClass')));
+
+        return $this->templater()->format('menuWrapper', [
+            'ariaLabel' => $options['ariaLabel'] ?? $this->getConfig('ariaLabel'),
+            'attributes' => $this->renderAttributes($attributes),
+            'items' => implode('', $items),
+        ]);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderBreadcrumbItem(ItemInterface $item, array $options, bool $isCurrent): string
+    {
+        $attributes = $this->appendClass([], (string)($options['itemClass'] ?? $this->getConfig('itemClass')));
+        if ($isCurrent) {
+            $attributes = $this->appendClass($attributes, (string)($options['activeClass'] ?? $this->getConfig('activeClass')));
+        }
+
+        $content = $this->renderContent($item, ['currentAsLink' => !$isCurrent] + $options);
+
+        return $this->templater()->format('item', [
+            'attributes' => $this->renderAttributes($attributes),
+            'content' => $content,
+        ]);
+    }
+}

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Renderer;
+
+use JsonException;
+use Menu\Item\ItemInterface;
+use Menu\MenuInterface;
+
+class JsonRenderer implements RendererInterface
+{
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function render(MenuInterface $menu, array $options = []): string
+    {
+        $flags = JSON_THROW_ON_ERROR;
+        if (!empty($options['pretty'])) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+
+        try {
+            return json_encode($menu->toArray(), $flags);
+        } catch (JsonException $exception) {
+            return '';
+        }
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function renderItem(ItemInterface $item, array $options = []): string
+    {
+        $flags = JSON_THROW_ON_ERROR;
+        if (!empty($options['pretty'])) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+
+        try {
+            return json_encode($item->toArray(), $flags);
+        } catch (JsonException $exception) {
+            return '';
+        }
+    }
+}

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -42,6 +42,9 @@ class StringTemplateRenderer implements RendererInterface
         'lastClass' => null,
         'depth' => null,
         'currentAsLink' => true,
+        'ariaLabel' => null,
+        'addAriaCurrent' => true,
+        'addAriaExpanded' => true,
         'templates' => [
             'menuWrapper' => '<ul{{attributes}}>{{items}}</ul>',
             'item' => '<li{{attributes}}>{{content}}</li>',
@@ -104,6 +107,10 @@ class StringTemplateRenderer implements RendererInterface
         }
 
         $attributes = $menu->getAttributes();
+        $ariaLabel = $this->getStringOption($options, 'ariaLabel');
+        if ($level === 1 && $ariaLabel !== '' && !isset($attributes['aria-label'])) {
+            $attributes['aria-label'] = $ariaLabel;
+        }
         if ($level > 1) {
             $nestedMenuClass = $this->getStringOption($options, 'nestedMenuClass');
             if ($nestedMenuClass !== '') {
@@ -159,6 +166,11 @@ class StringTemplateRenderer implements RendererInterface
         if ($hasSubMenu) {
             $attributes = $this->appendConfiguredClass($attributes, $options, 'branchClass');
             $attributes = $this->appendConfiguredClass($attributes, $options, 'submenuClass');
+            if ($this->getBooleanOption($options, 'addAriaExpanded', true)) {
+                $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() || $this->hasActiveDescendant($item)
+                    ? 'true'
+                    : 'false';
+            }
         } else {
             $attributes = $this->appendConfiguredClass($attributes, $options, 'leafClass');
         }
@@ -198,6 +210,9 @@ class StringTemplateRenderer implements RendererInterface
 
         $attributes = $link->getAttributes();
         $attributes['href'] = $link->getUrl() ?? '#';
+        if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
+            $attributes['aria-current'] = 'page';
+        }
 
         return $this->templater()->format('link', [
             'attributes' => $this->renderAttributes($attributes),

--- a/src/Resolver/AuthorizationResolver.php
+++ b/src/Resolver/AuthorizationResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Closure;
+use Menu\Item\ItemInterface;
+
+class AuthorizationResolver implements ContextAwareResolverInterface
+{
+    /**
+     * @var \Closure(\Menu\Item\ItemInterface, \Menu\Resolver\ResolverContext): (bool|null)
+     */
+    protected Closure $callback;
+
+    /**
+     * @param callable(\Menu\Item\ItemInterface, \Menu\Resolver\ResolverContext): (bool|null) $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = Closure::fromCallable($callback);
+    }
+
+    public function resolve(ItemInterface $item): void
+    {
+        $this->resolveWithContext($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
+    {
+        $allowed = ($this->callback)($item, $context);
+        if ($allowed !== null) {
+            $item->setVisibility($allowed);
+        }
+    }
+}

--- a/src/Resolver/CallbackResolver.php
+++ b/src/Resolver/CallbackResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Closure;
+use Menu\Item\ItemInterface;
+
+class CallbackResolver implements ContextAwareResolverInterface
+{
+    /**
+     * @var \Closure(\Menu\Item\ItemInterface, \Menu\Resolver\ResolverContext): void
+     */
+    protected Closure $callback;
+
+    /**
+     * @param callable(\Menu\Item\ItemInterface, \Menu\Resolver\ResolverContext): void $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = Closure::fromCallable($callback);
+    }
+
+    public function resolve(ItemInterface $item): void
+    {
+        ($this->callback)($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
+    {
+        ($this->callback)($item, $context);
+    }
+}

--- a/src/Resolver/ContextAwareResolverInterface.php
+++ b/src/Resolver/ContextAwareResolverInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Menu\Item\ItemInterface;
+
+interface ContextAwareResolverInterface extends ResolverInterface
+{
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void;
+}

--- a/src/Resolver/LoggedInResolver.php
+++ b/src/Resolver/LoggedInResolver.php
@@ -6,13 +6,18 @@ namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
 
-class LoggedInResolver implements ResolverInterface
+class LoggedInResolver implements ContextAwareResolverInterface
 {
     public function __construct(protected bool $loggedIn)
     {
     }
 
     public function resolve(ItemInterface $item): void
+    {
+        $this->resolveWithContext($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
     {
         $auth = $item->getData('auth');
         if ($auth === 'loggedIn') {

--- a/src/Resolver/PermissionResolver.php
+++ b/src/Resolver/PermissionResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Menu\Item\ItemInterface;
+use function is_string;
+use function method_exists;
+
+class PermissionResolver implements ContextAwareResolverInterface
+{
+    public function __construct(
+        protected object $authorizer,
+        protected mixed $identity = null,
+        protected string $dataKey = 'permission',
+        protected string $method = 'can',
+    ) {
+    }
+
+    public function resolve(ItemInterface $item): void
+    {
+        $this->resolveWithContext($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
+    {
+        $permission = $item->getData($this->dataKey);
+        if (!is_string($permission) || !method_exists($this->authorizer, $this->method)) {
+            return;
+        }
+
+        $allowed = $this->authorizer->{$this->method}($this->identity, $permission, $item, $context);
+        if (is_bool($allowed)) {
+            $item->setVisibility($allowed);
+        }
+    }
+}

--- a/src/Resolver/Psr7UrlResolver.php
+++ b/src/Resolver/Psr7UrlResolver.php
@@ -10,10 +10,11 @@ use Menu\Item\ItemInterface;
 use Psr\Http\Message\RequestInterface;
 use function array_filter;
 use function array_merge;
+use function is_int;
 use function is_string;
 use function parse_url;
 
-class Psr7UrlResolver implements ResolverInterface
+class Psr7UrlResolver implements ContextAwareResolverInterface
 {
     use InstanceConfigTrait;
 
@@ -22,6 +23,7 @@ class Psr7UrlResolver implements ResolverInterface
      */
     protected array $_defaultConfig = [
         'ignoreQueryString' => true,
+        'maxDepth' => null,
     ];
 
     /**
@@ -36,6 +38,16 @@ class Psr7UrlResolver implements ResolverInterface
 
     public function resolve(ItemInterface $item): void
     {
+        $this->resolveWithContext($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
+    {
+        $maxDepth = $this->getConfig('maxDepth');
+        if (is_int($maxDepth) && $context->getDepth() > $maxDepth) {
+            return;
+        }
+
         $requestUri = (string)$this->request->getUri();
         $requestPath = parse_url($requestUri, PHP_URL_PATH);
         $ignoreQueryString = $item instanceof Item && $item->getIgnoreQueryString() !== null

--- a/src/Resolver/ResolverCollection.php
+++ b/src/Resolver/ResolverCollection.php
@@ -7,7 +7,7 @@ namespace Menu\Resolver;
 use InvalidArgumentException;
 use Menu\Item\ItemInterface;
 
-class ResolverCollection implements ResolverCollectionInterface
+class ResolverCollection implements ResolverCollectionInterface, ContextAwareResolverInterface
 {
     /**
      * @var list<\Menu\Resolver\ResolverInterface>
@@ -48,7 +48,18 @@ class ResolverCollection implements ResolverCollectionInterface
 
     public function resolve(ItemInterface $item): void
     {
+        $this->resolveWithContext($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
+    {
         foreach ($this->resolvers as $resolver) {
+            if ($resolver instanceof ContextAwareResolverInterface) {
+                $resolver->resolveWithContext($item, $context);
+
+                continue;
+            }
+
             $resolver->resolve($item);
         }
     }

--- a/src/Resolver/ResolverCollectionInterface.php
+++ b/src/Resolver/ResolverCollectionInterface.php
@@ -23,4 +23,6 @@ interface ResolverCollectionInterface
     public function all(): array;
 
     public function resolve(ItemInterface $item): void;
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void;
 }

--- a/src/Resolver/ResolverContext.php
+++ b/src/Resolver/ResolverContext.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Menu\Item\ItemInterface;
+
+class ResolverContext
+{
+    public function __construct(
+        protected int $depth = 1,
+        protected ?ItemInterface $parent = null,
+    ) {
+    }
+
+    public function getDepth(): int
+    {
+        return $this->depth;
+    }
+
+    public function getParent(): ?ItemInterface
+    {
+        return $this->parent;
+    }
+}

--- a/src/Resolver/SectionResolver.php
+++ b/src/Resolver/SectionResolver.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Menu\Item\ItemInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use function array_is_list;
+use function is_array;
+use function is_string;
+
+class SectionResolver implements ContextAwareResolverInterface
+{
+    public function __construct(
+        protected ServerRequestInterface $request,
+        protected string $dataKey = 'section',
+        protected bool $expand = true,
+    ) {
+    }
+
+    public function resolve(ItemInterface $item): void
+    {
+        $this->resolveWithContext($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
+    {
+        $sections = $item->getData($this->dataKey);
+        if ($sections === null) {
+            return;
+        }
+
+        $requestParams = (array)$this->request->getAttribute('params');
+        foreach ($this->normalizeSections($sections) as $section) {
+            if ($this->matchesSection($requestParams, $section)) {
+                $item->setActive(true);
+                if ($this->expand) {
+                    $item->setExpanded();
+                }
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * @param mixed $sections
+     *
+     * @return list<array<string, mixed>>
+     */
+    protected function normalizeSections(mixed $sections): array
+    {
+        if (is_string($sections)) {
+            return [['controller' => $sections]];
+        }
+        if (!is_array($sections)) {
+            return [];
+        }
+        if (!array_is_list($sections)) {
+            /** @var array<string, mixed> $sections */
+            return [$sections];
+        }
+
+        $result = [];
+        foreach ($sections as $section) {
+            if (is_string($section)) {
+                $result[] = ['controller' => $section];
+            } elseif (is_array($section)) {
+                $result[] = $section;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $requestParams
+     * @param array<string, mixed> $section
+     */
+    protected function matchesSection(array $requestParams, array $section): bool
+    {
+        foreach ($section as $key => $value) {
+            if (($requestParams[$key] ?? null) !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Resolver/UrlArrayResolver.php
+++ b/src/Resolver/UrlArrayResolver.php
@@ -13,11 +13,12 @@ use function array_intersect_key;
 use function array_merge;
 use function array_walk;
 use function is_array;
+use function is_int;
 use function is_numeric;
 use function ksort;
 use const SORT_STRING;
 
-class UrlArrayResolver implements ResolverInterface
+class UrlArrayResolver implements ContextAwareResolverInterface
 {
     use InstanceConfigTrait;
 
@@ -26,6 +27,7 @@ class UrlArrayResolver implements ResolverInterface
      */
     protected array $_defaultConfig = [
         'fuzzy' => true,
+        'maxDepth' => null,
     ];
 
     /**
@@ -40,6 +42,16 @@ class UrlArrayResolver implements ResolverInterface
 
     public function resolve(ItemInterface $item): void
     {
+        $this->resolveWithContext($item, new ResolverContext());
+    }
+
+    public function resolveWithContext(ItemInterface $item, ResolverContext $context): void
+    {
+        $maxDepth = $this->getConfig('maxDepth');
+        if (is_int($maxDepth) && $context->getDepth() > $maxDepth) {
+            return;
+        }
+
         $link = $item->getLink();
         if ($link === null) {
             return;
@@ -68,6 +80,17 @@ class UrlArrayResolver implements ResolverInterface
     {
         $normalizedRequestParams = $this->extractParams($requestParams);
         $normalizedRoute = $this->normalizeRoute($linkArray);
+
+        if (isset($normalizedRoute['_name'])) {
+            if (($normalizedRequestParams['_name'] ?? null) !== $normalizedRoute['_name']) {
+                return false;
+            }
+
+            unset($normalizedRoute['_name'], $normalizedRequestParams['_name']);
+            if ($normalizedRoute === []) {
+                return true;
+            }
+        }
 
         $fuzzy = $item instanceof Item
             ? $item->isFuzzyMatch()
@@ -102,6 +125,10 @@ class UrlArrayResolver implements ResolverInterface
         $params['?'] = $this->request->getQueryParams();
         $params['_method'] = $this->request->getMethod();
         $params['_host'] = $this->request->getUri()->getHost();
+        $route = $params['_route'] ?? null;
+        if (is_object($route) && method_exists($route, 'getName')) {
+            $params['_name'] = $route->getName();
+        }
         if (!isset($params['_ext'])) {
             $params['_ext'] = null;
         }

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -96,6 +96,19 @@ class MenuHelper extends Helper
         return $this->create($name, $options);
     }
 
+    /**
+     * @param string $name
+     * @param callable(\Menu\MenuInterface, self): void $callback
+     * @param array<string, mixed> $options
+     */
+    public function register(string $name, callable $callback, array $options = []): MenuInterface
+    {
+        $menu = $this->getOrCreate($name, $options);
+        $callback($menu, $this);
+
+        return $menu;
+    }
+
     public function remove(string $name): static
     {
         unset($this->menus[$name], $this->menuConfigs[$name]);

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Menu\Item\ItemInterface;
 use Menu\Menu;
 use Menu\MenuInterface;
+use Menu\Renderer\BreadcrumbRenderer;
 use Menu\Renderer\RendererInterface;
 use Menu\Renderer\StringTemplateRenderer;
 use Menu\Resolver\Psr7UrlResolver;
@@ -19,9 +20,15 @@ use Menu\Resolver\UrlArrayResolver;
 
 /**
  * @extends \Cake\View\Helper<\Cake\View\View>
+ * @property \Cake\View\Helper\BreadcrumbsHelper $Breadcrumbs
  */
 class MenuHelper extends Helper
 {
+    /**
+     * @var list<string>
+     */
+    protected array $helpers = ['Breadcrumbs'];
+
     /**
      * @var array<string, \Menu\MenuInterface>
      */
@@ -40,6 +47,7 @@ class MenuHelper extends Helper
         'ignoreQueryString' => true,
         'fuzzy' => true,
         'currentAsLink' => true,
+        'resolveDepth' => null,
     ];
 
     /**
@@ -51,6 +59,9 @@ class MenuHelper extends Helper
     {
         if ($name === '') {
             throw new InvalidArgumentException('Menu name must not be empty.');
+        }
+        if (isset($this->menus[$name]) && empty($options['overwrite'])) {
+            throw new InvalidArgumentException(sprintf('Menu `%s` already exists.', $name));
         }
 
         $attributes = [];
@@ -66,6 +77,42 @@ class MenuHelper extends Helper
         $this->lastMenuName = $name;
 
         return $menu;
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->menus[$name]);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function getOrCreate(string $name, array $options = []): MenuInterface
+    {
+        if ($this->has($name)) {
+            return $this->get($name);
+        }
+
+        return $this->create($name, $options);
+    }
+
+    public function remove(string $name): static
+    {
+        unset($this->menus[$name], $this->menuConfigs[$name]);
+        if ($this->lastMenuName === $name) {
+            $this->lastMenuName = null;
+        }
+
+        return $this;
+    }
+
+    public function reset(): static
+    {
+        $this->menus = [];
+        $this->menuConfigs = [];
+        $this->lastMenuName = null;
+
+        return $this;
     }
 
     /**
@@ -115,6 +162,88 @@ class MenuHelper extends Helper
         }
 
         return array_reverse($path);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     *
+     * @return list<array{title: string, url: array<string|int, mixed>|string|null, options: array<string, mixed>}>
+     */
+    public function getBreadcrumbs(MenuInterface|string|null $menu = null, array $options = []): array
+    {
+        [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
+        $this->applyResolvers($menu, $resolvedOptions);
+
+        $currentItem = $menu->getActiveItem();
+        if ($currentItem === null) {
+            return [];
+        }
+
+        $path = $this->extractPath($currentItem);
+        $linkCurrent = (bool)($resolvedOptions['linkCurrent'] ?? false);
+
+        $crumbs = [];
+        foreach ($path as $index => $item) {
+            $isCurrent = $index === count($path) - 1;
+            $link = $item->getLink();
+            $optionsForCrumb = (array)($item->getData('breadcrumbOptions') ?? []);
+            if ($isCurrent) {
+                $optionsForCrumb['innerAttrs']['aria-current'] = 'page';
+            }
+
+            $crumbs[] = [
+                'title' => (string)$item->getLabel(),
+                'url' => $link !== null && (!$isCurrent || $linkCurrent) ? $link->getRawUrl() : null,
+                'options' => $optionsForCrumb,
+            ];
+        }
+
+        return $crumbs;
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function populateBreadcrumbs(MenuInterface|string|null $menu = null, array $options = []): static
+    {
+        $reset = !array_key_exists('resetBreadcrumbs', $options) || (bool)$options['resetBreadcrumbs'];
+        if ($reset) {
+            $this->Breadcrumbs->reset();
+        }
+
+        $this->Breadcrumbs->addMany($this->getBreadcrumbs($menu, $options));
+
+        return $this;
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     * @phpstan-param array<string, mixed> $attributes
+     * @phpstan-param array<string, mixed> $separator
+     */
+    public function renderBreadcrumbs(
+        MenuInterface|string|null $menu = null,
+        array $options = [],
+        array $attributes = [],
+        array $separator = [],
+    ): string {
+        $renderer = $options['renderer'] ?? null;
+        if ($renderer === BreadcrumbRenderer::class || $renderer instanceof BreadcrumbRenderer) {
+            [$resolvedMenu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
+            $this->applyResolvers($resolvedMenu, $resolvedOptions);
+            $activeItem = $resolvedMenu->getActiveItem();
+            if ($activeItem === null) {
+                return '';
+            }
+
+            $resolvedOptions['path'] = $this->extractPath($activeItem);
+
+            return $this->getRenderer(['renderer' => BreadcrumbRenderer::class] + $resolvedOptions)->render($resolvedMenu, $resolvedOptions);
+        }
+
+        $this->populateBreadcrumbs($menu, $options);
+
+        return $this->Breadcrumbs->render($attributes, $separator);
     }
 
     /**
@@ -173,11 +302,17 @@ class MenuHelper extends Helper
         return (new ResolverCollection())
             ->add(new UrlArrayResolver(
                 $this->getView()->getRequest(),
-                ['fuzzy' => $options['fuzzy'] ?? true],
+                [
+                    'fuzzy' => $options['fuzzy'] ?? true,
+                    'maxDepth' => $options['resolveDepth'] ?? null,
+                ],
             ))
             ->add(new Psr7UrlResolver(
                 $this->getView()->getRequest(),
-                ['ignoreQueryString' => $options['ignoreQueryString'] ?? true],
+                [
+                    'ignoreQueryString' => $options['ignoreQueryString'] ?? true,
+                    'maxDepth' => $options['resolveDepth'] ?? null,
+                ],
             ));
     }
 

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -6,6 +6,7 @@ namespace Menu\Test\TestCase\Menu;
 
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use LogicException;
 use Menu\Menu;
 use Menu\Resolver\CallbackResolver;
 use Menu\Resolver\UrlArrayResolver;
@@ -113,5 +114,56 @@ class MenuTest extends TestCase
             'articles' => 1,
             'view' => 2,
         ], $depths);
+    }
+
+    public function testFromArrayToArrayRoundTrip(): void
+    {
+        $menu = Menu::fromArray([
+            'attributes' => ['class' => 'nav'],
+            'data' => ['area' => 'main'],
+            'items' => [
+                [
+                    'id' => 'articles',
+                    'label' => 'Articles',
+                    'link' => '/articles',
+                    'data' => ['weight' => 10],
+                    'submenu' => [
+                        'items' => [
+                            [
+                                'id' => 'view',
+                                'label' => 'View',
+                                'link' => '/articles/view',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $export = $menu->toArray();
+
+        $this->assertSame('nav', $export['attributes']['class']);
+        $this->assertSame('main', $export['data']['area']);
+        $this->assertSame('articles', $export['items'][0]['id']);
+        $this->assertSame('view', $export['items'][0]['submenu']['items'][0]['id']);
+    }
+
+    public function testFreezePreventsStructuralMutation(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Articles', '/articles');
+        $menu->freeze();
+
+        $this->expectException(LogicException::class);
+        $menu->addItem('Users', '/users');
+    }
+
+    public function testRejectsDuplicateExplicitKeys(): void
+    {
+        $this->expectExceptionMessage('Duplicate explicit menu item key `content` detected.');
+
+        $menu = Menu::create();
+        $menu->addItem('Articles', '/articles', ['key' => 'content']);
+        $menu->addItem('Pages', '/pages', ['key' => 'content']);
     }
 }

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -7,6 +7,7 @@ namespace Menu\Test\TestCase\Menu;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use Menu\Menu;
+use Menu\Resolver\CallbackResolver;
 use Menu\Resolver\UrlArrayResolver;
 
 class MenuTest extends TestCase
@@ -86,5 +87,31 @@ class MenuTest extends TestCase
 
         $this->assertNull($menu->getActiveItem());
         $this->assertFalse($child->isActive());
+    }
+
+    public function testRejectsDuplicateIds(): void
+    {
+        $this->expectExceptionMessage('Duplicate menu item id `articles` detected.');
+
+        $menu = Menu::create();
+        $menu->addItem('Articles', '/articles', ['id' => 'articles']);
+        $menu->addItem('Articles 2', '/articles-2', ['id' => 'articles']);
+    }
+
+    public function testResolveWithCallbackResolverIncludesContextDepth(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Articles', '/articles', ['id' => 'articles']);
+        $parent->getSubMenu()->addItem('View', '/articles/view', ['id' => 'view']);
+
+        $depths = [];
+        $menu->resolve(new CallbackResolver(function ($item, $context) use (&$depths): void {
+            $depths[$item->getId()] = $context->getDepth();
+        }));
+
+        $this->assertSame([
+            'articles' => 1,
+            'view' => 2,
+        ], $depths);
     }
 }

--- a/tests/TestCase/Renderer/Bootstrap5RendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5RendererTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Renderer;
+
+use Cake\TestSuite\TestCase;
+use Menu\Menu;
+use Menu\Renderer\Bootstrap5Renderer;
+
+class Bootstrap5RendererTest extends TestCase
+{
+    public function testRendersBootstrapStyleClasses(): void
+    {
+        $menu = Menu::create(['class' => 'navbar-nav']);
+        $parent = $menu->addItem('Account', '#');
+        $parent->getSubMenu()->addItem('Profile', '/profile');
+
+        $result = (new Bootstrap5Renderer())->render($menu);
+
+        $this->assertStringContainsString('class="dropdown"', $result);
+        $this->assertStringContainsString('class="dropdown-menu"', $result);
+    }
+}

--- a/tests/TestCase/Renderer/BreadcrumbRendererTest.php
+++ b/tests/TestCase/Renderer/BreadcrumbRendererTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Renderer;
+
+use Cake\TestSuite\TestCase;
+use Menu\Menu;
+use Menu\Renderer\BreadcrumbRenderer;
+
+class BreadcrumbRendererTest extends TestCase
+{
+    public function testRendersActivePath(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Articles', '/articles');
+        $parent->getSubMenu()->addItem('View', '/articles/view', ['active' => true]);
+
+        $result = (new BreadcrumbRenderer())->render($menu);
+
+        $this->assertStringContainsString('<nav aria-label="breadcrumb">', $result);
+        $this->assertStringContainsString('<ol class="breadcrumb">', $result);
+        $this->assertStringContainsString('<a href="/articles">Articles</a>', $result);
+        $this->assertStringContainsString('<li class="breadcrumb-item active"><span>View</span></li>', $result);
+    }
+}

--- a/tests/TestCase/Renderer/JsonRendererTest.php
+++ b/tests/TestCase/Renderer/JsonRendererTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Renderer;
+
+use Cake\TestSuite\TestCase;
+use Menu\Menu;
+use Menu\Renderer\JsonRenderer;
+
+class JsonRendererTest extends TestCase
+{
+    public function testRendersMenuAsJson(): void
+    {
+        $menu = Menu::create(['class' => 'nav']);
+        $menu->addItem('Articles', '/articles', ['id' => 'articles']);
+
+        $result = (new JsonRenderer())->render($menu);
+        $data = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('nav', $data['attributes']['class']);
+        $this->assertSame('articles', $data['items'][0]['id']);
+    }
+}

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -19,7 +19,7 @@ class StringTemplateRendererTest extends TestCase
         $result = (new StringTemplateRenderer())->render($menu);
 
         $this->assertStringContainsString('First&lt;&gt;', $result);
-        $this->assertStringContainsString('<li class="active"><a href="/second">Second</a></li>', $result);
+        $this->assertStringContainsString('<li class="active"><a href="/second" aria-current="page">Second</a></li>', $result);
     }
 
     public function testRendersRawItemWithoutEscaping(): void
@@ -65,5 +65,21 @@ class StringTemplateRendererTest extends TestCase
         $this->assertStringContainsString('<li class="first">', $result);
         $this->assertStringContainsString('class="has-children last"', $result);
         $this->assertStringContainsString('<ul class="submenu level-2">', $result);
+    }
+
+    public function testAddsAriaCurrentAndExpandedState(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Articles', '/articles');
+        $parent->setExpanded();
+        $parent->getSubMenu()->addItem('View', '/articles/view', ['active' => true]);
+
+        $result = (new StringTemplateRenderer([
+            'ariaLabel' => 'Main navigation',
+        ]))->render($menu);
+
+        $this->assertStringContainsString('<ul aria-label="Main navigation">', $result);
+        $this->assertStringContainsString('aria-expanded="true"', $result);
+        $this->assertStringContainsString('aria-current="page"', $result);
     }
 }

--- a/tests/TestCase/Resolver/AuthorizationResolverTest.php
+++ b/tests/TestCase/Resolver/AuthorizationResolverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Resolver;
+
+use Cake\TestSuite\TestCase;
+use Menu\Item\Item;
+use Menu\Item\ItemInterface;
+use Menu\Resolver\AuthorizationResolver;
+use Menu\Resolver\ResolverContext;
+
+class AuthorizationResolverTest extends TestCase
+{
+    public function testHidesUnauthorizedItems(): void
+    {
+        $item = (new Item('Admin', '/admin'))->setData('role', 'admin');
+
+        $resolver = new AuthorizationResolver(static function (ItemInterface $item, ResolverContext $context): ?bool {
+            if ($item->getData('role') === 'admin') {
+                return false;
+            }
+
+            return null;
+        });
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isVisible());
+    }
+}

--- a/tests/TestCase/Resolver/PermissionResolverTest.php
+++ b/tests/TestCase/Resolver/PermissionResolverTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Resolver;
+
+use Cake\TestSuite\TestCase;
+use Menu\Item\Item;
+use Menu\Resolver\PermissionResolver;
+
+class PermissionResolverTest extends TestCase
+{
+    public function testUsesAuthorizerCanMethod(): void
+    {
+        $item = (new Item('Admin', '/admin'))->setData('permission', 'admin.access');
+        $authorizer = new class {
+            public function can(mixed $identity, string $permission): bool
+            {
+                return $permission !== 'admin.access';
+            }
+        };
+
+        (new PermissionResolver($authorizer, ['id' => 1]))->resolve($item);
+
+        $this->assertFalse($item->isVisible());
+    }
+}

--- a/tests/TestCase/Resolver/SectionResolverTest.php
+++ b/tests/TestCase/Resolver/SectionResolverTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Resolver;
+
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Menu\Item\Item;
+use Menu\Resolver\SectionResolver;
+
+class SectionResolverTest extends TestCase
+{
+    public function testMatchesControllerSectionAndExpandsItem(): void
+    {
+        $item = (new Item('Articles', '/articles'))->setData('section', [
+            'controller' => 'Articles',
+            'prefix' => 'Admin',
+        ]);
+
+        $request = (new ServerRequest())
+            ->withAttribute('params', [
+                'controller' => 'Articles',
+                'prefix' => 'Admin',
+                'action' => 'index',
+            ]);
+
+        (new SectionResolver($request))->resolve($item);
+
+        $this->assertTrue($item->isActive());
+        $this->assertTrue($item->isExpanded());
+    }
+}

--- a/tests/TestCase/Resolver/UrlArrayResolverTest.php
+++ b/tests/TestCase/Resolver/UrlArrayResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Test\TestCase\Resolver;
 
 use Cake\Http\ServerRequest;
+use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
 use Menu\Item\Item;
 use Menu\Resolver\UrlArrayResolver;
@@ -76,6 +77,23 @@ class UrlArrayResolverTest extends TestCase
                 'action' => 'index',
             ])
             ->withQueryParams(['sort' => 'desc', 'page' => '2']);
+
+        $resolver = new UrlArrayResolver($request);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testMatchesNamedRoute(): void
+    {
+        $item = new Item('View Article', ['_name' => 'articles:view']);
+
+        $request = (new ServerRequest())
+            ->withAttribute('params', [
+                'controller' => 'Articles',
+                'action' => 'view',
+                '_route' => new Route('/articles/{id}', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'articles:view']),
+            ]);
 
         $resolver = new UrlArrayResolver($request);
         $resolver->resolve($item);

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -164,6 +164,18 @@ class MenuHelperTest extends TestCase
         $menuHelper->create('main');
     }
 
+    public function testRegisterBuildsMenuLazily(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest());
+
+        $menu = $menuHelper->register('main', static function ($menu): void {
+            $menu->addItem('Articles', '/articles');
+        });
+
+        $this->assertSame($menu, $menuHelper->get('main'));
+        $this->assertCount(1, $menu->getItems());
+    }
+
     public function testAuthorizationResolverAndDepthLimit(): void
     {
         $request = (new ServerRequest(['url' => '/articles/view/42']))

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -6,9 +6,15 @@ namespace Menu\Test\TestCase\View\Helper;
 
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
+use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
+use Menu\Item\ItemInterface;
 use Menu\Menu;
+use Menu\Renderer\BreadcrumbRenderer;
+use Menu\Resolver\AuthorizationResolver;
+use Menu\Resolver\ResolverCollection;
+use Menu\Resolver\ResolverContext;
 use Menu\View\Helper\MenuHelper;
 
 class MenuHelperTest extends TestCase
@@ -84,5 +90,109 @@ class MenuHelperTest extends TestCase
 
         $this->assertSame($child, $currentItem);
         $this->assertSame([$parent, $child], $path);
+    }
+
+    public function testHelperLifecycleMethods(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest());
+        $menuHelper->create('main');
+
+        $this->assertTrue($menuHelper->has('main'));
+
+        $menuHelper->remove('main');
+        $this->assertFalse($menuHelper->has('main'));
+
+        $menuHelper->create('secondary');
+        $menuHelper->reset();
+
+        $this->assertFalse($menuHelper->has('secondary'));
+    }
+
+    public function testGetBreadcrumbsAndRenderBreadcrumbs(): void
+    {
+        $request = (new ServerRequest(['url' => '/articles/view/42']))
+            ->withAttribute('params', [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'pass' => [42],
+            ])
+            ->withUri((new ServerRequest())->getUri()->withPath('/articles/view/42'));
+        $menuHelper = $this->createHelper($request);
+
+        $menu = $menuHelper->create('main');
+        $parent = $menu->addItem('Articles', '/articles');
+        $parent->getSubMenu()->addItem('View', '/articles/view/42');
+
+        $crumbs = $menuHelper->getBreadcrumbs('main');
+        $html = $menuHelper->renderBreadcrumbs('main');
+
+        $this->assertCount(2, $crumbs);
+        $this->assertSame('Articles', $crumbs[0]['title']);
+        $this->assertSame('/articles', $crumbs[0]['url']);
+        $this->assertNull($crumbs[1]['url']);
+        $this->assertStringContainsString('<ul>', $html);
+        $this->assertStringContainsString('aria-current="page"', $html);
+    }
+
+    public function testRenderBreadcrumbsWithBreadcrumbRenderer(): void
+    {
+        $request = (new ServerRequest(['url' => '/articles/view']))
+            ->withAttribute('params', [
+                'controller' => 'Articles',
+                'action' => 'view',
+                '_route' => new Route('/articles/view', ['controller' => 'Articles', 'action' => 'view'], ['_name' => 'articles:view']),
+            ])
+            ->withUri((new ServerRequest())->getUri()->withPath('/articles/view'));
+        $menuHelper = $this->createHelper($request);
+
+        $menu = $menuHelper->create('main');
+        $menu->addItem('Articles', ['_name' => 'articles:view']);
+
+        $html = $menuHelper->renderBreadcrumbs('main', ['renderer' => BreadcrumbRenderer::class]);
+
+        $this->assertStringContainsString('<nav aria-label="breadcrumb">', $html);
+    }
+
+    public function testGetOrCreateAndDuplicateCreateProtection(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest());
+        $menu = $menuHelper->getOrCreate('main');
+
+        $this->assertSame($menu, $menuHelper->getOrCreate('main'));
+
+        $this->expectExceptionMessage('Menu `main` already exists.');
+        $menuHelper->create('main');
+    }
+
+    public function testAuthorizationResolverAndDepthLimit(): void
+    {
+        $request = (new ServerRequest(['url' => '/articles/view/42']))
+            ->withAttribute('params', [
+                'controller' => 'Articles',
+                'action' => 'view',
+                'pass' => [42],
+            ])
+            ->withUri((new ServerRequest())->getUri()->withPath('/articles/view/42'));
+        $menuHelper = $this->createHelper($request);
+
+        $menu = $menuHelper->create('main');
+        $menu->addItem('Admin', '/admin', ['data' => ['role' => 'admin']]);
+        $parent = $menu->addItem('Articles', '/articles');
+        $parent->getSubMenu()->addItem('View', '/articles/view/42');
+
+        $html = $menuHelper->render('main', [
+            'resolveDepth' => 1,
+            'resolver' => (new ResolverCollection())
+                ->add(new AuthorizationResolver(static function (ItemInterface $item, ResolverContext $context): ?bool {
+                    if ($item->getData('role') === 'admin') {
+                        return false;
+                    }
+
+                    return null;
+                })),
+        ]);
+
+        $this->assertStringNotContainsString('Admin', $html);
+        $this->assertNull($menuHelper->getCurrentItem('main', ['resolveDepth' => 1]));
     }
 }


### PR DESCRIPTION
## Summary

This expands the plugin from a small nested menu helper into a more complete navigation toolkit for CakePHP 5 while keeping the root README slim and moving the detailed guidance into `docs/README.md`.

## What changed

- Added breadcrumb support through `MenuHelper::getBreadcrumbs()`, `populateBreadcrumbs()`, and `renderBreadcrumbs()`.
- Added `BreadcrumbRenderer`, `JsonRenderer`, and `Bootstrap5Renderer`.
- Added helper lifecycle and lazy registration methods: `has()`, `getOrCreate()`, `register()`, `remove()`, and `reset()`.
- Added context-aware resolving with `ResolverContext` and `ContextAwareResolverInterface`.
- Added `CallbackResolver`, `AuthorizationResolver`, `PermissionResolver`, and `SectionResolver`.
- Extended URL resolution with named-route support and optional depth limits.
- Added accessibility-focused rendering improvements including `aria-current`, `aria-expanded`, and top-level `aria-label` support.
- Added menu import/export via `Menu::fromArray()` and `toArray()`.
- Added freeze support for locking menu structure after definition while keeping runtime state resolvable.
- Added duplicate item id protection and duplicate explicit key protection.
- Kept the root `README.md` concise and moved the detailed cookbook guidance into `docs/README.md`.
- Expanded test coverage for breadcrumbs, helper lifecycle, authorization, named-route matching, accessibility, import/export, freeze mode, JSON output, Bootstrap presets, section matching, and permission checks.

## Notes

- `renderBreadcrumbs()` reuses Cake's `BreadcrumbsHelper` by default and can switch to the plugin's `BreadcrumbRenderer` when needed.
- `resolveDepth` is available through helper rendering options for apps that only want shallow automatic active-state scans.