### PR TITLE
Fix menu helper follow-up issues

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,8 @@ $this->Menu->register('main', static function ($menu): void {
 });
 ```
 
+`register()` is idempotent by default and returns the existing named menu on repeated calls. Pass `['rebuild' => true]` if you want to rebuild the menu definition.
+
 ## Item Options
 
 `Menu::addItem()` and `Menu::newItem()` accept these options:
@@ -316,6 +318,7 @@ echo $this->Menu->render($menu, [
 - `before`, `after`, and `raw` are treated as trusted markup.
 - String URLs and array URLs are both supported.
 - Active matching is automatic in the helper by default and uses both array and string resolvers.
+- Each helper render/request-state lookup resets runtime `active`, `visible`, and `expanded` state before applying resolvers again.
 - The default renderer emits `aria-current="page"` for the active link and `aria-expanded` for branch items.
 
 ## Recipes

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ $this->Menu->register('main', static function ($menu): void {
 });
 ```
 
-`register()` is idempotent by default and returns the existing named menu on repeated calls. Pass `['rebuild' => true]` if you want to rebuild the menu definition.
+`register()` is idempotent by default and returns the existing named menu on repeated calls. Pass `['rebuild' => true]` if you want to replace the existing named menu and rebuild its definition from scratch.
 
 ## Item Options
 
@@ -318,7 +318,8 @@ echo $this->Menu->render($menu, [
 - `before`, `after`, and `raw` are treated as trusted markup.
 - String URLs and array URLs are both supported.
 - Active matching is automatic in the helper by default and uses both array and string resolvers.
-- Each helper render/request-state lookup resets runtime `active`, `visible`, and `expanded` state before applying resolvers again.
+- Each helper render/request-state lookup applies resolvers temporarily and restores the original `active`, `visible`, and `expanded` item state afterward.
+- Custom item classes should extend `Menu\Item\Item` or implement `Menu\Item\StateResetInterface` if you want `Menu::resetState()` to restore their original runtime defaults.
 - The default renderer emits `aria-current="page"` for the active link and `aria-expanded` for branch items.
 
 ## Recipes

--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -11,7 +11,7 @@ use Menu\Link\LinkInterface;
 use Menu\Menu;
 use Menu\MenuInterface;
 
-class Item implements ItemInterface
+class Item implements ItemInterface, StateResetInterface
 {
     protected string $id;
 
@@ -31,7 +31,11 @@ class Item implements ItemInterface
 
     protected bool $visible = true;
 
+    protected bool $defaultVisible = true;
+
     protected bool $active = false;
+
+    protected bool $defaultActive = false;
 
     protected string $before = '';
 
@@ -61,6 +65,8 @@ class Item implements ItemInterface
     protected bool $fuzzyMatch = false;
 
     protected bool $expanded = false;
+
+    protected bool $defaultExpanded = false;
 
     protected bool $frozen = false;
 
@@ -189,6 +195,7 @@ class Item implements ItemInterface
     public function setVisibility(bool $isVisible): static
     {
         $this->visible = $isVisible;
+        $this->defaultVisible = $isVisible;
 
         return $this;
     }
@@ -201,6 +208,7 @@ class Item implements ItemInterface
     public function setActive(bool $isActive): static
     {
         $this->active = $isActive;
+        $this->defaultActive = $isActive;
 
         return $this;
     }
@@ -399,6 +407,7 @@ class Item implements ItemInterface
     public function setExpanded(bool $expanded = true): static
     {
         $this->expanded = $expanded;
+        $this->defaultExpanded = $expanded;
 
         return $this;
     }
@@ -447,6 +456,36 @@ class Item implements ItemInterface
             'fuzzy' => $this->fuzzyMatch,
             'submenu' => $this->subMenu?->toArray(),
         ];
+    }
+
+    public function resetState(): static
+    {
+        $this->visible = $this->defaultVisible;
+        $this->active = $this->defaultActive;
+        $this->expanded = $this->defaultExpanded;
+
+        return $this;
+    }
+
+    public function setRuntimeVisibility(bool $isVisible): static
+    {
+        $this->visible = $isVisible;
+
+        return $this;
+    }
+
+    public function setRuntimeActive(bool $isActive): static
+    {
+        $this->active = $isActive;
+
+        return $this;
+    }
+
+    public function setRuntimeExpanded(bool $expanded = true): static
+    {
+        $this->expanded = $expanded;
+
+        return $this;
     }
 
     protected function assertMutable(): void

--- a/src/Item/StateResetInterface.php
+++ b/src/Item/StateResetInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Item;
+
+interface StateResetInterface
+{
+    public function resetState(): static;
+
+    public function setRuntimeVisibility(bool $isVisible): static;
+
+    public function setRuntimeActive(bool $isActive): static;
+
+    public function setRuntimeExpanded(bool $expanded = true): static;
+}

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -304,7 +304,11 @@ class Menu implements MenuInterface
     public function clearActive(): static
     {
         foreach ($this->items as $item) {
-            $item->setActive(false);
+            if ($item instanceof StateResetInterface) {
+                $item->setRuntimeActive(false);
+            } else {
+                $item->setActive(false);
+            }
             if ($item->hasSubMenu()) {
                 $item->getSubMenu()->clearActive();
             }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -101,7 +101,7 @@ class Menu implements MenuInterface
             if (!empty($itemConfig['expanded'])) {
                 $item->setExpanded();
             }
-            if (!empty($itemConfig['submenu']['items'])) {
+            if (!empty($itemConfig['submenu']) && is_array($itemConfig['submenu'])) {
                 $item->setSubMenu(static::fromArray((array)$itemConfig['submenu']));
             }
 
@@ -459,6 +459,11 @@ class Menu implements MenuInterface
     {
         $this->assertMutable();
         $this->ownerItem = $ownerItem;
+        foreach ($this->items as $item) {
+            if (!$item->hasParent()) {
+                $item->setParent($ownerItem);
+            }
+        }
 
         return $this;
     }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use LogicException;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 use Menu\Link\Link;
 use Menu\Link\LinkInterface;
 use Menu\Resolver\ContextAwareResolverInterface;
@@ -250,6 +251,11 @@ class Menu implements MenuInterface
 
         $this->assertUniqueItems($validatedItems);
         $this->items = $validatedItems;
+        if ($this->ownerItem !== null) {
+            foreach ($this->items as $item) {
+                $item->setParent($this->ownerItem);
+            }
+        }
 
         return $this;
     }
@@ -462,6 +468,22 @@ class Menu implements MenuInterface
         foreach ($this->items as $item) {
             if (!$item->hasParent()) {
                 $item->setParent($ownerItem);
+            }
+        }
+
+        return $this;
+    }
+
+    public function resetState(): static
+    {
+        foreach ($this->items as $item) {
+            if ($item instanceof StateResetInterface) {
+                $item->resetState();
+            } else {
+                $item->setActive(false);
+            }
+            if ($item->hasSubMenu()) {
+                $item->getSubMenu()->resetState();
             }
         }
 

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -107,6 +107,8 @@ interface MenuInterface
 
     public function resolve(ResolverInterface|ResolverCollectionInterface $resolver): static;
 
+    public function resetState(): static;
+
     public function freeze(): static;
 
     public function isFrozen(): bool;

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -35,22 +35,40 @@ class Bootstrap5Renderer extends StringTemplateRenderer
      */
     protected function renderContent(ItemInterface $item, array $options): string
     {
-        $link = $item->getLink();
-        if ($link !== null) {
-            $attributes = $link->getAttributes();
-            $baseLinkClass = $item->hasParent() ? 'dropdown-item' : 'nav-link';
-            if ($item->hasSubMenu()) {
-                $attributes['class'] = array_filter([$baseLinkClass, 'dropdown-toggle', $attributes['class'] ?? null]);
-                $attributes['data-bs-toggle'] = 'dropdown';
-                $attributes['role'] = $attributes['role'] ?? 'button';
-                $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() ? 'true' : 'false';
-                $link->setAttributes($attributes);
-            } else {
-                $attributes['class'] = array_filter([$baseLinkClass, $attributes['class'] ?? null]);
-                $link->setAttributes($attributes);
-            }
+        if ($item->isRaw()) {
+            return (string)$item->getRaw();
         }
 
-        return parent::renderContent($item, $options);
+        $label = $this->escapeLabel($item);
+        $link = $item->getLink();
+        if ($link === null || ($item->isActive() && !$this->getBooleanOption($options, 'currentAsLink', true))) {
+            $attributes = $link?->getAttributes() ?? [];
+            unset($attributes['href']);
+
+            return $this->templater()->format('label', [
+                'attributes' => $this->renderAttributes($attributes),
+                'title' => $label,
+            ]);
+        }
+
+        $attributes = $link->getAttributes();
+        $attributes['href'] = $link->getUrl() ?? '#';
+        $baseLinkClass = $item->hasParent() ? 'dropdown-item' : 'nav-link';
+        if ($item->hasSubMenu()) {
+            $attributes['class'] = array_filter([$baseLinkClass, 'dropdown-toggle', $attributes['class'] ?? null]);
+            $attributes['data-bs-toggle'] = 'dropdown';
+            $attributes['role'] = $attributes['role'] ?? 'button';
+            $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() ? 'true' : 'false';
+        } else {
+            $attributes['class'] = array_filter([$baseLinkClass, $attributes['class'] ?? null]);
+        }
+        if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
+            $attributes['aria-current'] = 'page';
+        }
+
+        return $this->templater()->format('link', [
+            'attributes' => $this->renderAttributes($attributes),
+            'title' => $label,
+        ]);
     }
 }

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -58,7 +58,9 @@ class Bootstrap5Renderer extends StringTemplateRenderer
             $attributes['class'] = array_filter([$baseLinkClass, 'dropdown-toggle', $attributes['class'] ?? null]);
             $attributes['data-bs-toggle'] = 'dropdown';
             $attributes['role'] = $attributes['role'] ?? 'button';
-            $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() ? 'true' : 'false';
+            $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() || $this->hasActiveDescendant($item)
+                ? 'true'
+                : 'false';
         } else {
             $attributes['class'] = array_filter([$baseLinkClass, $attributes['class'] ?? null]);
         }

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -38,15 +38,15 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         $link = $item->getLink();
         if ($link !== null) {
             $attributes = $link->getAttributes();
+            $baseLinkClass = $item->hasParent() ? 'dropdown-item' : 'nav-link';
             if ($item->hasSubMenu()) {
-                $attributes['class'] = array_filter(['nav-link', 'dropdown-toggle', $attributes['class'] ?? null]);
+                $attributes['class'] = array_filter([$baseLinkClass, 'dropdown-toggle', $attributes['class'] ?? null]);
                 $attributes['data-bs-toggle'] = 'dropdown';
                 $attributes['role'] = $attributes['role'] ?? 'button';
                 $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() ? 'true' : 'false';
                 $link->setAttributes($attributes);
             } else {
-                $linkClass = $item->hasParent() ? 'dropdown-item' : 'nav-link';
-                $attributes['class'] = array_filter([$linkClass, $attributes['class'] ?? null]);
+                $attributes['class'] = array_filter([$baseLinkClass, $attributes['class'] ?? null]);
                 $link->setAttributes($attributes);
             }
         }

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Menu\Renderer;
 
+use Menu\Item\ItemInterface;
+
 class Bootstrap5Renderer extends StringTemplateRenderer
 {
     /**
@@ -27,4 +29,27 @@ class Bootstrap5Renderer extends StringTemplateRenderer
             'divider' => '<li{{attributes}}><hr class="dropdown-divider"></li>',
         ],
     ];
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderContent(ItemInterface $item, array $options): string
+    {
+        $link = $item->getLink();
+        if ($link !== null) {
+            $attributes = $link->getAttributes();
+            if ($item->hasSubMenu()) {
+                $attributes['class'] = array_filter(['nav-link', 'dropdown-toggle', $attributes['class'] ?? null]);
+                $attributes['data-bs-toggle'] = 'dropdown';
+                $attributes['role'] = $attributes['role'] ?? 'button';
+                $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() ? 'true' : 'false';
+                $link->setAttributes($attributes);
+            } else {
+                $attributes['class'] = array_filter(['dropdown-item', $attributes['class'] ?? null]);
+                $link->setAttributes($attributes);
+            }
+        }
+
+        return parent::renderContent($item, $options);
+    }
 }

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -16,6 +16,7 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         'ancestorClass' => 'active',
         'branchClass' => 'dropdown',
         'submenuClass' => 'dropdown',
+        'addAriaExpanded' => false,
         'nestedMenuClass' => 'dropdown-menu',
         'menuLevelClass' => null,
         'firstClass' => null,

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -45,7 +45,8 @@ class Bootstrap5Renderer extends StringTemplateRenderer
                 $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() ? 'true' : 'false';
                 $link->setAttributes($attributes);
             } else {
-                $attributes['class'] = array_filter(['dropdown-item', $attributes['class'] ?? null]);
+                $linkClass = $item->hasParent() ? 'dropdown-item' : 'nav-link';
+                $attributes['class'] = array_filter([$linkClass, $attributes['class'] ?? null]);
                 $link->setAttributes($attributes);
             }
         }

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Menu\Renderer;
 
-use JsonException;
 use Menu\Item\ItemInterface;
 use Menu\MenuInterface;
 
@@ -20,11 +19,7 @@ class JsonRenderer implements RendererInterface
             $flags |= JSON_PRETTY_PRINT;
         }
 
-        try {
-            return json_encode($menu->toArray(), $flags);
-        } catch (JsonException $exception) {
-            return '';
-        }
+        return json_encode($menu->toArray(), $flags);
     }
 
     /**
@@ -37,10 +32,6 @@ class JsonRenderer implements RendererInterface
             $flags |= JSON_PRETTY_PRINT;
         }
 
-        try {
-            return json_encode($item->toArray(), $flags);
-        } catch (JsonException $exception) {
-            return '';
-        }
+        return json_encode($item->toArray(), $flags);
     }
 }

--- a/src/Resolver/AuthorizationResolver.php
+++ b/src/Resolver/AuthorizationResolver.php
@@ -6,6 +6,7 @@ namespace Menu\Resolver;
 
 use Closure;
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 
 class AuthorizationResolver implements ContextAwareResolverInterface
 {
@@ -31,7 +32,11 @@ class AuthorizationResolver implements ContextAwareResolverInterface
     {
         $allowed = ($this->callback)($item, $context);
         if ($allowed !== null) {
-            $item->setVisibility($allowed);
+            if ($item instanceof StateResetInterface) {
+                $item->setRuntimeVisibility($allowed);
+            } else {
+                $item->setVisibility($allowed);
+            }
         }
     }
 }

--- a/src/Resolver/LoggedInResolver.php
+++ b/src/Resolver/LoggedInResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 
 class LoggedInResolver implements ContextAwareResolverInterface
 {
@@ -21,9 +22,17 @@ class LoggedInResolver implements ContextAwareResolverInterface
     {
         $auth = $item->getData('auth');
         if ($auth === 'loggedIn') {
-            $item->setVisibility($this->loggedIn);
+            if ($item instanceof StateResetInterface) {
+                $item->setRuntimeVisibility($this->loggedIn);
+            } else {
+                $item->setVisibility($this->loggedIn);
+            }
         } elseif ($auth === 'loggedOut') {
-            $item->setVisibility(!$this->loggedIn);
+            if ($item instanceof StateResetInterface) {
+                $item->setRuntimeVisibility(!$this->loggedIn);
+            } else {
+                $item->setVisibility(!$this->loggedIn);
+            }
         }
     }
 }

--- a/src/Resolver/PermissionResolver.php
+++ b/src/Resolver/PermissionResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 use ReflectionMethod;
 use function is_string;
 use function method_exists;
@@ -33,7 +34,11 @@ class PermissionResolver implements ContextAwareResolverInterface
 
         $allowed = $this->invokeAuthorizer($permission, $item, $context);
         if (is_bool($allowed)) {
-            $item->setVisibility($allowed);
+            if ($item instanceof StateResetInterface) {
+                $item->setRuntimeVisibility($allowed);
+            } else {
+                $item->setVisibility($allowed);
+            }
         }
     }
 

--- a/src/Resolver/PermissionResolver.php
+++ b/src/Resolver/PermissionResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
+use ReflectionMethod;
 use function is_string;
 use function method_exists;
 
@@ -30,9 +31,23 @@ class PermissionResolver implements ContextAwareResolverInterface
             return;
         }
 
-        $allowed = $this->authorizer->{$this->method}($this->identity, $permission, $item, $context);
+        $allowed = $this->invokeAuthorizer($permission, $item, $context);
         if (is_bool($allowed)) {
             $item->setVisibility($allowed);
         }
+    }
+
+    protected function invokeAuthorizer(string $permission, ItemInterface $item, ResolverContext $context): mixed
+    {
+        $reflectionMethod = new ReflectionMethod($this->authorizer, $this->method);
+        $parameterCount = $reflectionMethod->getNumberOfParameters();
+
+        return match (true) {
+            $parameterCount >= 4 => $this->authorizer->{$this->method}($this->identity, $permission, $item, $context),
+            $parameterCount === 3 => $this->authorizer->{$this->method}($this->identity, $permission, $item),
+            $parameterCount === 2 => $this->authorizer->{$this->method}($this->identity, $permission),
+            $parameterCount === 1 => $this->authorizer->{$this->method}($permission),
+            default => $this->authorizer->{$this->method}(),
+        };
     }
 }

--- a/src/Resolver/PermissionResolver.php
+++ b/src/Resolver/PermissionResolver.php
@@ -12,6 +12,8 @@ use function method_exists;
 
 class PermissionResolver implements ContextAwareResolverInterface
 {
+    protected ?int $parameterCount = null;
+
     public function __construct(
         protected object $authorizer,
         protected mixed $identity = null,
@@ -44,14 +46,16 @@ class PermissionResolver implements ContextAwareResolverInterface
 
     protected function invokeAuthorizer(string $permission, ItemInterface $item, ResolverContext $context): mixed
     {
-        $reflectionMethod = new ReflectionMethod($this->authorizer, $this->method);
-        $parameterCount = $reflectionMethod->getNumberOfParameters();
+        if ($this->parameterCount === null) {
+            $reflectionMethod = new ReflectionMethod($this->authorizer, $this->method);
+            $this->parameterCount = $reflectionMethod->getNumberOfParameters();
+        }
 
         return match (true) {
-            $parameterCount >= 4 => $this->authorizer->{$this->method}($this->identity, $permission, $item, $context),
-            $parameterCount === 3 => $this->authorizer->{$this->method}($this->identity, $permission, $item),
-            $parameterCount === 2 => $this->authorizer->{$this->method}($this->identity, $permission),
-            $parameterCount === 1 => $this->authorizer->{$this->method}($permission),
+            $this->parameterCount >= 4 => $this->authorizer->{$this->method}($this->identity, $permission, $item, $context),
+            $this->parameterCount === 3 => $this->authorizer->{$this->method}($this->identity, $permission, $item),
+            $this->parameterCount === 2 => $this->authorizer->{$this->method}($this->identity, $permission),
+            $this->parameterCount === 1 => $this->authorizer->{$this->method}($permission),
             default => $this->authorizer->{$this->method}(),
         };
     }

--- a/src/Resolver/Psr7UrlResolver.php
+++ b/src/Resolver/Psr7UrlResolver.php
@@ -7,6 +7,7 @@ namespace Menu\Resolver;
 use Cake\Core\InstanceConfigTrait;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 use Psr\Http\Message\RequestInterface;
 use function array_filter;
 use function array_merge;
@@ -60,7 +61,11 @@ class Psr7UrlResolver implements ContextAwareResolverInterface
             }
 
             if ($requestUri === $route) {
-                $item->setActive(true);
+                if ($item instanceof StateResetInterface) {
+                    $item->setRuntimeActive(true);
+                } else {
+                    $item->setActive(true);
+                }
 
                 return;
             }
@@ -71,7 +76,11 @@ class Psr7UrlResolver implements ContextAwareResolverInterface
 
             $routePath = parse_url($route, PHP_URL_PATH);
             if ($requestPath === $routePath) {
-                $item->setActive(true);
+                if ($item instanceof StateResetInterface) {
+                    $item->setRuntimeActive(true);
+                } else {
+                    $item->setActive(true);
+                }
 
                 return;
             }

--- a/src/Resolver/SectionResolver.php
+++ b/src/Resolver/SectionResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use function array_is_list;
 use function is_array;
@@ -34,9 +35,17 @@ class SectionResolver implements ContextAwareResolverInterface
         $requestParams = (array)$this->request->getAttribute('params');
         foreach ($this->normalizeSections($sections) as $section) {
             if ($this->matchesSection($requestParams, $section)) {
-                $item->setActive(true);
+                if ($item instanceof StateResetInterface) {
+                    $item->setRuntimeActive(true);
+                } else {
+                    $item->setActive(true);
+                }
                 if ($this->expand) {
-                    $item->setExpanded();
+                    if ($item instanceof StateResetInterface) {
+                        $item->setRuntimeExpanded();
+                    } else {
+                        $item->setExpanded();
+                    }
                 }
 
                 return;

--- a/src/Resolver/UrlArrayResolver.php
+++ b/src/Resolver/UrlArrayResolver.php
@@ -7,6 +7,7 @@ namespace Menu\Resolver;
 use Cake\Core\InstanceConfigTrait;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use function array_filter;
 use function array_intersect_key;
@@ -65,7 +66,11 @@ class UrlArrayResolver implements ContextAwareResolverInterface
         $requestParams = (array)$this->request->getAttribute('params');
         foreach ($this->extractRoutes($item, $linkArray) as $route) {
             if ($this->matches($requestParams, $route, $item)) {
-                $item->setActive(true);
+                if ($item instanceof StateResetInterface) {
+                    $item->setRuntimeActive(true);
+                } else {
+                    $item->setActive(true);
+                }
 
                 return;
             }

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\View\Helper;
 
 use Cake\View\Helper;
+use Closure;
 use InvalidArgumentException;
 use Menu\Item\ItemInterface;
 use Menu\Item\StateResetInterface;
@@ -18,6 +19,7 @@ use Menu\Resolver\ResolverCollection;
 use Menu\Resolver\ResolverCollectionInterface;
 use Menu\Resolver\ResolverInterface;
 use Menu\Resolver\UrlArrayResolver;
+use ReflectionFunction;
 
 /**
  * @extends \Cake\View\Helper<\Cake\View\View>
@@ -99,7 +101,7 @@ class MenuHelper extends Helper
 
     /**
      * @param string $name
-     * @param callable(\Menu\MenuInterface, self): void $callback
+     * @param callable(\Menu\MenuInterface): void|callable(\Menu\MenuInterface, self): void $callback
      * @param array<string, mixed> $options
      */
     public function register(string $name, callable $callback, array $options = []): MenuInterface
@@ -112,13 +114,13 @@ class MenuHelper extends Helper
             $options['overwrite'] = true;
             $menu = $this->create($name, $options);
 
-            $callback($menu, $this);
+            $this->invokeRegisterCallback($callback, $menu);
 
             return $menu;
         }
 
         $menu = $this->getOrCreate($name, $options);
-        $callback($menu, $this);
+        $this->invokeRegisterCallback($callback, $menu);
 
         return $menu;
     }
@@ -339,6 +341,18 @@ class MenuHelper extends Helper
 
         $menu->resetState();
         $menu->resolve($resolver);
+    }
+
+    protected function invokeRegisterCallback(callable $callback, MenuInterface $menu): void
+    {
+        $reflectionFunction = new ReflectionFunction(Closure::fromCallable($callback));
+        if ($reflectionFunction->getNumberOfParameters() <= 1) {
+            $callback($menu);
+
+            return;
+        }
+
+        $callback($menu, $this);
     }
 
     /**

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -103,6 +103,14 @@ class MenuHelper extends Helper
      */
     public function register(string $name, callable $callback, array $options = []): MenuInterface
     {
+        if ($this->has($name) && empty($options['rebuild'])) {
+            return $this->get($name);
+        }
+
+        if (!empty($options['rebuild'])) {
+            $options['overwrite'] = true;
+        }
+
         $menu = $this->getOrCreate($name, $options);
         $callback($menu, $this);
 
@@ -146,7 +154,7 @@ class MenuHelper extends Helper
     public function render(MenuInterface|string|null $menu = null, array $options = []): string
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $this->applyResolvers($menu, $resolvedOptions);
+        $menu = $this->applyResolvers($menu, $resolvedOptions);
 
         return $this->getRenderer($resolvedOptions)->render($menu, $resolvedOptions);
     }
@@ -157,7 +165,7 @@ class MenuHelper extends Helper
     public function getCurrentItem(MenuInterface|string|null $menu = null, array $options = []): ?ItemInterface
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $this->applyResolvers($menu, $resolvedOptions);
+        $menu = $this->applyResolvers($menu, $resolvedOptions);
 
         return $menu->getActiveItem();
     }
@@ -185,7 +193,7 @@ class MenuHelper extends Helper
     public function getBreadcrumbs(MenuInterface|string|null $menu = null, array $options = []): array
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $this->applyResolvers($menu, $resolvedOptions);
+        $menu = $this->applyResolvers($menu, $resolvedOptions);
 
         $currentItem = $menu->getActiveItem();
         if ($currentItem === null) {
@@ -243,7 +251,7 @@ class MenuHelper extends Helper
         $renderer = $options['renderer'] ?? null;
         if ($renderer === BreadcrumbRenderer::class || $renderer instanceof BreadcrumbRenderer) {
             [$resolvedMenu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-            $this->applyResolvers($resolvedMenu, $resolvedOptions);
+            $resolvedMenu = $this->applyResolvers($resolvedMenu, $resolvedOptions);
             $activeItem = $resolvedMenu->getActiveItem();
             if ($activeItem === null) {
                 return '';
@@ -292,12 +300,13 @@ class MenuHelper extends Helper
      *
      * @throws \InvalidArgumentException
      */
-    protected function applyResolvers(MenuInterface $menu, array $options): void
+    protected function applyResolvers(MenuInterface $menu, array $options): MenuInterface
     {
         if (($options['resolve'] ?? true) !== true) {
-            return;
+            return $menu;
         }
 
+        $menu = $this->cloneMenu($menu);
         $resolver = $options['resolver'] ?? $this->createDefaultResolver($options);
         if (!$resolver instanceof ResolverInterface && !$resolver instanceof ResolverCollectionInterface) {
             throw new InvalidArgumentException('Resolver must implement ResolverInterface or ResolverCollectionInterface.');
@@ -305,6 +314,8 @@ class MenuHelper extends Helper
 
         $menu->clearActive();
         $menu->resolve($resolver);
+
+        return $menu;
     }
 
     /**
@@ -347,5 +358,10 @@ class MenuHelper extends Helper
 
         /** @var class-string<\Menu\Renderer\RendererInterface> $renderer */
         return new $renderer($options);
+    }
+
+    protected function cloneMenu(MenuInterface $menu): MenuInterface
+    {
+        return $menu::fromArray($menu->toArray());
     }
 }

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -7,6 +7,7 @@ namespace Menu\View\Helper;
 use Cake\View\Helper;
 use InvalidArgumentException;
 use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
 use Menu\Menu;
 use Menu\MenuInterface;
 use Menu\Renderer\BreadcrumbRenderer;
@@ -109,6 +110,11 @@ class MenuHelper extends Helper
 
         if (!empty($options['rebuild'])) {
             $options['overwrite'] = true;
+            $menu = $this->create($name, $options);
+
+            $callback($menu, $this);
+
+            return $menu;
         }
 
         $menu = $this->getOrCreate($name, $options);
@@ -154,9 +160,14 @@ class MenuHelper extends Helper
     public function render(MenuInterface|string|null $menu = null, array $options = []): string
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $this->applyResolvers($menu, $resolvedOptions);
+        $state = $this->captureItemState($menu);
+        try {
+            $this->applyResolvers($menu, $resolvedOptions);
 
-        return $this->getRenderer($resolvedOptions)->render($menu, $resolvedOptions);
+            return $this->getRenderer($resolvedOptions)->render($menu, $resolvedOptions);
+        } finally {
+            $this->restoreItemState($menu, $state);
+        }
     }
 
     /**
@@ -165,9 +176,14 @@ class MenuHelper extends Helper
     public function getCurrentItem(MenuInterface|string|null $menu = null, array $options = []): ?ItemInterface
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $this->applyResolvers($menu, $resolvedOptions);
+        $state = $this->captureItemState($menu);
+        try {
+            $this->applyResolvers($menu, $resolvedOptions);
 
-        return $menu->getActiveItem();
+            return $menu->getActiveItem();
+        } finally {
+            $this->restoreItemState($menu, $state);
+        }
     }
 
     /**
@@ -193,33 +209,38 @@ class MenuHelper extends Helper
     public function getBreadcrumbs(MenuInterface|string|null $menu = null, array $options = []): array
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $this->applyResolvers($menu, $resolvedOptions);
+        $state = $this->captureItemState($menu);
+        try {
+            $this->applyResolvers($menu, $resolvedOptions);
 
-        $currentItem = $menu->getActiveItem();
-        if ($currentItem === null) {
-            return [];
-        }
-
-        $path = $this->extractPath($currentItem);
-        $linkCurrent = (bool)($resolvedOptions['linkCurrent'] ?? false);
-
-        $crumbs = [];
-        foreach ($path as $index => $item) {
-            $isCurrent = $index === count($path) - 1;
-            $link = $item->getLink();
-            $optionsForCrumb = (array)($item->getData('breadcrumbOptions') ?? []);
-            if ($isCurrent) {
-                $optionsForCrumb['innerAttrs']['aria-current'] = 'page';
+            $currentItem = $menu->getActiveItem();
+            if ($currentItem === null) {
+                return [];
             }
 
-            $crumbs[] = [
-                'title' => (string)$item->getLabel(),
-                'url' => $link !== null && (!$isCurrent || $linkCurrent) ? $link->getRawUrl() : null,
-                'options' => $optionsForCrumb,
-            ];
-        }
+            $path = $this->extractPath($currentItem);
+            $linkCurrent = (bool)($resolvedOptions['linkCurrent'] ?? false);
 
-        return $crumbs;
+            $crumbs = [];
+            foreach ($path as $index => $item) {
+                $isCurrent = $index === count($path) - 1;
+                $link = $item->getLink();
+                $optionsForCrumb = (array)($item->getData('breadcrumbOptions') ?? []);
+                if ($isCurrent) {
+                    $optionsForCrumb['innerAttrs']['aria-current'] = 'page';
+                }
+
+                $crumbs[] = [
+                    'title' => (string)$item->getLabel(),
+                    'url' => $link !== null && (!$isCurrent || $linkCurrent) ? $link->getRawUrl() : null,
+                    'options' => $optionsForCrumb,
+                ];
+            }
+
+            return $crumbs;
+        } finally {
+            $this->restoreItemState($menu, $state);
+        }
     }
 
     /**
@@ -251,15 +272,20 @@ class MenuHelper extends Helper
         $renderer = $options['renderer'] ?? null;
         if ($renderer === BreadcrumbRenderer::class || $renderer instanceof BreadcrumbRenderer) {
             [$resolvedMenu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-            $this->applyResolvers($resolvedMenu, $resolvedOptions);
-            $activeItem = $resolvedMenu->getActiveItem();
-            if ($activeItem === null) {
-                return '';
+            $state = $this->captureItemState($resolvedMenu);
+            try {
+                $this->applyResolvers($resolvedMenu, $resolvedOptions);
+                $activeItem = $resolvedMenu->getActiveItem();
+                if ($activeItem === null) {
+                    return '';
+                }
+
+                $resolvedOptions['path'] = $this->extractPath($activeItem);
+
+                return $this->getRenderer(['renderer' => BreadcrumbRenderer::class] + $resolvedOptions)->render($resolvedMenu, $resolvedOptions);
+            } finally {
+                $this->restoreItemState($resolvedMenu, $state);
             }
-
-            $resolvedOptions['path'] = $this->extractPath($activeItem);
-
-            return $this->getRenderer(['renderer' => BreadcrumbRenderer::class] + $resolvedOptions)->render($resolvedMenu, $resolvedOptions);
         }
 
         $this->populateBreadcrumbs($menu, $options);
@@ -313,6 +339,51 @@ class MenuHelper extends Helper
 
         $menu->resetState();
         $menu->resolve($resolver);
+    }
+
+    /**
+     * @return array<int, array{visible: bool, active: bool, expanded: bool}>
+     */
+    protected function captureItemState(MenuInterface $menu): array
+    {
+        $state = [];
+        foreach ($menu->getItems() as $item) {
+            $state[spl_object_id($item)] = [
+                'visible' => $item->isVisible(),
+                'active' => $item->isActive(),
+                'expanded' => $item->isExpanded(),
+            ];
+            if ($item->hasSubMenu()) {
+                $state += $this->captureItemState($item->getSubMenu());
+            }
+        }
+
+        return $state;
+    }
+
+    /**
+     * @param \Menu\MenuInterface $menu
+     * @param array<int, array{visible: bool, active: bool, expanded: bool}> $state
+     */
+    protected function restoreItemState(MenuInterface $menu, array $state): void
+    {
+        foreach ($menu->getItems() as $item) {
+            $itemState = $state[spl_object_id($item)] ?? null;
+            if ($itemState !== null) {
+                if ($item instanceof StateResetInterface) {
+                    $item->setRuntimeVisibility($itemState['visible']);
+                    $item->setRuntimeActive($itemState['active']);
+                    $item->setRuntimeExpanded($itemState['expanded']);
+                } else {
+                    $item->setVisibility($itemState['visible']);
+                    $item->setActive($itemState['active']);
+                    $item->setExpanded($itemState['expanded']);
+                }
+            }
+            if ($item->hasSubMenu()) {
+                $this->restoreItemState($item->getSubMenu(), $state);
+            }
+        }
     }
 
     /**

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -154,7 +154,7 @@ class MenuHelper extends Helper
     public function render(MenuInterface|string|null $menu = null, array $options = []): string
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $menu = $this->applyResolvers($menu, $resolvedOptions);
+        $this->applyResolvers($menu, $resolvedOptions);
 
         return $this->getRenderer($resolvedOptions)->render($menu, $resolvedOptions);
     }
@@ -165,7 +165,7 @@ class MenuHelper extends Helper
     public function getCurrentItem(MenuInterface|string|null $menu = null, array $options = []): ?ItemInterface
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $menu = $this->applyResolvers($menu, $resolvedOptions);
+        $this->applyResolvers($menu, $resolvedOptions);
 
         return $menu->getActiveItem();
     }
@@ -193,7 +193,7 @@ class MenuHelper extends Helper
     public function getBreadcrumbs(MenuInterface|string|null $menu = null, array $options = []): array
     {
         [$menu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-        $menu = $this->applyResolvers($menu, $resolvedOptions);
+        $this->applyResolvers($menu, $resolvedOptions);
 
         $currentItem = $menu->getActiveItem();
         if ($currentItem === null) {
@@ -251,7 +251,7 @@ class MenuHelper extends Helper
         $renderer = $options['renderer'] ?? null;
         if ($renderer === BreadcrumbRenderer::class || $renderer instanceof BreadcrumbRenderer) {
             [$resolvedMenu, $resolvedOptions] = $this->resolveMenuAndOptions($menu, $options);
-            $resolvedMenu = $this->applyResolvers($resolvedMenu, $resolvedOptions);
+            $this->applyResolvers($resolvedMenu, $resolvedOptions);
             $activeItem = $resolvedMenu->getActiveItem();
             if ($activeItem === null) {
                 return '';
@@ -300,22 +300,19 @@ class MenuHelper extends Helper
      *
      * @throws \InvalidArgumentException
      */
-    protected function applyResolvers(MenuInterface $menu, array $options): MenuInterface
+    protected function applyResolvers(MenuInterface $menu, array $options): void
     {
         if (($options['resolve'] ?? true) !== true) {
-            return $menu;
+            return;
         }
 
-        $menu = $this->cloneMenu($menu);
         $resolver = $options['resolver'] ?? $this->createDefaultResolver($options);
         if (!$resolver instanceof ResolverInterface && !$resolver instanceof ResolverCollectionInterface) {
             throw new InvalidArgumentException('Resolver must implement ResolverInterface or ResolverCollectionInterface.');
         }
 
-        $menu->clearActive();
+        $menu->resetState();
         $menu->resolve($resolver);
-
-        return $menu;
     }
 
     /**
@@ -358,10 +355,5 @@ class MenuHelper extends Helper
 
         /** @var class-string<\Menu\Renderer\RendererInterface> $renderer */
         return new $renderer($options);
-    }
-
-    protected function cloneMenu(MenuInterface $menu): MenuInterface
-    {
-        return $menu::fromArray($menu->toArray());
     }
 }

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -7,6 +7,7 @@ namespace Menu\Test\TestCase\Menu;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use LogicException;
+use Menu\Item\Item;
 use Menu\Menu;
 use Menu\Resolver\CallbackResolver;
 use Menu\Resolver\UrlArrayResolver;
@@ -177,5 +178,21 @@ class MenuTest extends TestCase
         $menu = Menu::create();
         $menu->addItem('Articles', '/articles', ['key' => 'content']);
         $menu->addItem('Pages', '/pages', ['key' => 'content']);
+    }
+
+    public function testSetItemsReparentsMovedSubmenuItems(): void
+    {
+        $menu = Menu::create();
+        $firstParent = $menu->addItem('First', '/first', ['id' => 'first']);
+        $secondParent = $menu->addItem('Second', '/second', ['id' => 'second']);
+        $child = (new Item('Child', '/child'))->setId('child');
+
+        $firstParent->getSubMenu()->setItems([$child]);
+        $this->assertSame($firstParent, $child->getParent());
+
+        $secondParent->getSubMenu()->setItems([$child]);
+
+        $this->assertSame($secondParent, $child->getParent());
+        $this->assertSame($child, $secondParent->getSubMenu()->get('child'));
     }
 }

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -91,6 +91,19 @@ class MenuTest extends TestCase
         $this->assertFalse($child->isActive());
     }
 
+    public function testClearActiveDoesNotDestroyResetStateBaseline(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Articles', '/articles', ['id' => 'articles']);
+        $child = $parent->getSubMenu()->addItem('View', '/articles/view', ['id' => 'view', 'active' => true]);
+
+        $menu->clearActive();
+        $menu->resetState();
+
+        $this->assertSame($child, $menu->getActiveItem());
+        $this->assertTrue($child->isActive());
+    }
+
     public function testRejectsDuplicateIds(): void
     {
         $this->expectExceptionMessage('Duplicate menu item id `articles` detected.');

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -137,6 +137,16 @@ class MenuTest extends TestCase
                         ],
                     ],
                 ],
+                [
+                    'id' => 'account',
+                    'label' => 'Account',
+                    'link' => '#',
+                    'submenu' => [
+                        'attributes' => ['class' => 'dropdown-menu'],
+                        'data' => ['kind' => 'account'],
+                        'items' => [],
+                    ],
+                ],
             ],
         ]);
 
@@ -146,6 +156,8 @@ class MenuTest extends TestCase
         $this->assertSame('main', $export['data']['area']);
         $this->assertSame('articles', $export['items'][0]['id']);
         $this->assertSame('view', $export['items'][0]['submenu']['items'][0]['id']);
+        $this->assertSame('dropdown-menu', $export['items'][1]['submenu']['attributes']['class']);
+        $this->assertSame('account', $export['items'][1]['submenu']['data']['kind']);
     }
 
     public function testFreezePreventsStructuralMutation(): void

--- a/tests/TestCase/Renderer/Bootstrap5RendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5RendererTest.php
@@ -18,12 +18,18 @@ class Bootstrap5RendererTest extends TestCase
         $settings = $parent->getSubMenu()->addItem('Settings', '#');
         $settings->getSubMenu()->addItem('Profile', '/profile');
 
-        $result = (new Bootstrap5Renderer())->render($menu);
+        $renderer = new Bootstrap5Renderer();
+        $result = $renderer->render($menu);
+        $secondResult = $renderer->render($menu);
 
-        $this->assertStringContainsString('<a class="nav-link" href="/">Home</a>', $result);
+        $this->assertStringContainsString('href="/"', $result);
+        $this->assertStringContainsString('class="nav-link"', $result);
         $this->assertStringContainsString('class="dropdown"', $result);
         $this->assertStringContainsString('class="dropdown-menu"', $result);
         $this->assertStringContainsString('class="dropdown-item dropdown-toggle"', $result);
-        $this->assertStringContainsString('class="dropdown-item" href="/profile"', $result);
+        $this->assertStringContainsString('href="/profile"', $result);
+        $this->assertStringContainsString('class="dropdown-item"', $result);
+        $this->assertSame($result, $secondResult);
+        $this->assertStringNotContainsString('Array', $secondResult);
     }
 }

--- a/tests/TestCase/Renderer/Bootstrap5RendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5RendererTest.php
@@ -13,12 +13,15 @@ class Bootstrap5RendererTest extends TestCase
     public function testRendersBootstrapStyleClasses(): void
     {
         $menu = Menu::create(['class' => 'navbar-nav']);
+        $menu->addItem('Home', '/');
         $parent = $menu->addItem('Account', '#');
         $parent->getSubMenu()->addItem('Profile', '/profile');
 
         $result = (new Bootstrap5Renderer())->render($menu);
 
+        $this->assertStringContainsString('<a class="nav-link" href="/">Home</a>', $result);
         $this->assertStringContainsString('class="dropdown"', $result);
         $this->assertStringContainsString('class="dropdown-menu"', $result);
+        $this->assertStringContainsString('class="dropdown-item" href="/profile"', $result);
     }
 }

--- a/tests/TestCase/Renderer/Bootstrap5RendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5RendererTest.php
@@ -16,7 +16,7 @@ class Bootstrap5RendererTest extends TestCase
         $menu->addItem('Home', '/');
         $parent = $menu->addItem('Account', '#');
         $settings = $parent->getSubMenu()->addItem('Settings', '#');
-        $settings->getSubMenu()->addItem('Profile', '/profile');
+        $settings->getSubMenu()->addItem('Profile', '/profile', ['active' => true]);
 
         $renderer = new Bootstrap5Renderer();
         $result = $renderer->render($menu);
@@ -24,9 +24,10 @@ class Bootstrap5RendererTest extends TestCase
 
         $this->assertStringContainsString('href="/"', $result);
         $this->assertStringContainsString('class="nav-link"', $result);
-        $this->assertStringContainsString('class="dropdown"', $result);
+        $this->assertMatchesRegularExpression('/class="[^"]*dropdown[^"]*"/', $result);
         $this->assertStringContainsString('class="dropdown-menu"', $result);
         $this->assertStringContainsString('class="dropdown-item dropdown-toggle"', $result);
+        $this->assertStringContainsString('aria-expanded="true"', $result);
         $this->assertStringContainsString('href="/profile"', $result);
         $this->assertStringContainsString('class="dropdown-item"', $result);
         $this->assertSame($result, $secondResult);

--- a/tests/TestCase/Renderer/Bootstrap5RendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5RendererTest.php
@@ -15,13 +15,15 @@ class Bootstrap5RendererTest extends TestCase
         $menu = Menu::create(['class' => 'navbar-nav']);
         $menu->addItem('Home', '/');
         $parent = $menu->addItem('Account', '#');
-        $parent->getSubMenu()->addItem('Profile', '/profile');
+        $settings = $parent->getSubMenu()->addItem('Settings', '#');
+        $settings->getSubMenu()->addItem('Profile', '/profile');
 
         $result = (new Bootstrap5Renderer())->render($menu);
 
         $this->assertStringContainsString('<a class="nav-link" href="/">Home</a>', $result);
         $this->assertStringContainsString('class="dropdown"', $result);
         $this->assertStringContainsString('class="dropdown-menu"', $result);
+        $this->assertStringContainsString('class="dropdown-item dropdown-toggle"', $result);
         $this->assertStringContainsString('class="dropdown-item" href="/profile"', $result);
     }
 }

--- a/tests/TestCase/Renderer/JsonRendererTest.php
+++ b/tests/TestCase/Renderer/JsonRendererTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Menu\Test\TestCase\Renderer;
 
 use Cake\TestSuite\TestCase;
+use JsonException;
+use Menu\Item\Item;
 use Menu\Menu;
 use Menu\Renderer\JsonRenderer;
 
@@ -20,5 +22,15 @@ class JsonRendererTest extends TestCase
 
         $this->assertSame('nav', $data['attributes']['class']);
         $this->assertSame('articles', $data['items'][0]['id']);
+    }
+
+    public function testThrowsOnEncodingError(): void
+    {
+        $menu = Menu::create();
+        $menu->add((new Item("\xB1\x31", '/broken'))->setId('broken'));
+
+        $this->expectException(JsonException::class);
+
+        (new JsonRenderer())->render($menu);
     }
 }

--- a/tests/TestCase/Resolver/PermissionResolverTest.php
+++ b/tests/TestCase/Resolver/PermissionResolverTest.php
@@ -24,4 +24,19 @@ class PermissionResolverTest extends TestCase
 
         $this->assertFalse($item->isVisible());
     }
+
+    public function testSupportsTwoArgumentCanMethod(): void
+    {
+        $item = (new Item('Admin', '/admin'))->setData('permission', 'admin.access');
+        $authorizer = new class {
+            public function can(mixed $identity, string $permission): bool
+            {
+                return $permission !== 'admin.access';
+            }
+        };
+
+        (new PermissionResolver($authorizer, ['id' => 1]))->resolve($item);
+
+        $this->assertFalse($item->isVisible());
+    }
 }

--- a/tests/TestCase/Resolver/PermissionResolverTest.php
+++ b/tests/TestCase/Resolver/PermissionResolverTest.php
@@ -39,4 +39,22 @@ class PermissionResolverTest extends TestCase
 
         $this->assertFalse($item->isVisible());
     }
+
+    public function testSupportsFourArgumentCanMethod(): void
+    {
+        $item = (new Item('Admin', '/admin'))->setData('permission', 'admin.access');
+        $authorizer = new class {
+            public function can(mixed $identity, string $permission, Item $item, object $context): bool
+            {
+                return $identity === ['id' => 1]
+                    && $permission === 'admin.access'
+                    && $item->getLabel() === 'Admin'
+                    && method_exists($context, 'getDepth');
+            }
+        };
+
+        (new PermissionResolver($authorizer, ['id' => 1]))->resolve($item);
+
+        $this->assertTrue($item->isVisible());
+    }
 }

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -9,7 +9,9 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
+use Menu\Item\Item;
 use Menu\Item\ItemInterface;
+use Menu\Item\SelfRendererInterface;
 use Menu\Menu;
 use Menu\Renderer\BreadcrumbRenderer;
 use Menu\Resolver\AuthorizationResolver;
@@ -20,6 +22,22 @@ use Menu\View\Helper\MenuHelper;
 
 class MenuHelperTest extends TestCase
 {
+    protected function createSelfRenderingItem(string $label, string $url, string $id): ItemInterface
+    {
+        return new class ($label, $url, $id) extends Item implements SelfRendererInterface {
+            public function __construct(string $label, string $url, string $id)
+            {
+                parent::__construct($label, $url);
+                $this->setId($id);
+            }
+
+            public function render(): string
+            {
+                return '<li class="custom-item">custom</li>';
+            }
+        };
+    }
+
     protected function createHelper(ServerRequest $request): MenuHelper
     {
         return new MenuHelper(new View(
@@ -182,6 +200,21 @@ class MenuHelperTest extends TestCase
         $this->assertCount(1, $menu->getItems());
     }
 
+    public function testRegisterCanRebuildExistingMenu(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest());
+
+        $menuHelper->register('main', static function ($menu): void {
+            $menu->addItem('Articles', '/articles');
+        });
+        $rebuiltMenu = $menuHelper->register('main', static function ($menu): void {
+            $menu->addItem('Users', '/users');
+        }, ['rebuild' => true]);
+
+        $this->assertCount(1, $rebuiltMenu->getItems());
+        $this->assertSame('Users', $rebuiltMenu->getItems()[0]->getLabel());
+    }
+
     public function testRenderResetsResolverStateBetweenCalls(): void
     {
         $request = (new ServerRequest(['url' => '/articles']))
@@ -220,6 +253,22 @@ class MenuHelperTest extends TestCase
         $this->assertTrue($menu->getItems()[0]->isVisible());
         $this->assertFalse($menu->getItems()[1]->isActive());
         $this->assertFalse($menu->getItems()[1]->isExpanded());
+    }
+
+    public function testRenderPreservesSelfRenderingCustomItems(): void
+    {
+        $request = (new ServerRequest(['url' => '/custom']))
+            ->withUri((new ServerRequest())->getUri()->withPath('/custom'));
+        $menuHelper = $this->createHelper($request);
+
+        $menu = $menuHelper->create('main');
+        $item = $this->createSelfRenderingItem('Custom', '/custom', 'custom');
+        $menu->add($item);
+
+        $html = $menuHelper->render('main');
+
+        $this->assertStringContainsString('<li class="custom-item">custom</li>', $html);
+        $this->assertSame($item, $menu->get('custom'));
     }
 
     public function testAuthorizationResolverAndDepthLimit(): void

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -89,11 +89,8 @@ class MenuHelperTest extends TestCase
         $currentItem = $menuHelper->getCurrentItem('main');
         $path = $menuHelper->extractPath($child);
 
-        $this->assertSame('View', $currentItem?->getLabel());
-        $this->assertSame(['Articles', 'View'], array_map(
-            static fn (ItemInterface $item): ?string => $item->getLabel(),
-            $path,
-        ));
+        $this->assertSame($child, $currentItem);
+        $this->assertSame([$parent, $child], $path);
     }
 
     public function testHelperLifecycleMethods(): void
@@ -185,7 +182,7 @@ class MenuHelperTest extends TestCase
         $this->assertCount(1, $menu->getItems());
     }
 
-    public function testRenderDoesNotLeakResolverStateIntoStoredMenu(): void
+    public function testRenderResetsResolverStateBetweenCalls(): void
     {
         $request = (new ServerRequest(['url' => '/articles']))
             ->withAttribute('params', [
@@ -201,7 +198,7 @@ class MenuHelperTest extends TestCase
             'data' => ['section' => ['controller' => 'Articles']],
         ]);
 
-        $menuHelper->render('main', [
+        $firstHtml = $menuHelper->render('main', [
             'resolver' => (new ResolverCollection())
                 ->add(new SectionResolver($request))
                 ->add(new AuthorizationResolver(static function (ItemInterface $item, ResolverContext $context): ?bool {
@@ -212,7 +209,14 @@ class MenuHelperTest extends TestCase
                     return null;
                 })),
         ]);
+        $secondHtml = $menuHelper->render('main', [
+            'resolver' => new ResolverCollection(),
+        ]);
 
+        $this->assertStringNotContainsString('Admin', $firstHtml);
+        $this->assertStringContainsString('class="active"', $firstHtml);
+        $this->assertStringContainsString('Admin', $secondHtml);
+        $this->assertStringNotContainsString('class="active"', $secondHtml);
         $this->assertTrue($menu->getItems()[0]->isVisible());
         $this->assertFalse($menu->getItems()[1]->isActive());
         $this->assertFalse($menu->getItems()[1]->isExpanded());

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -200,6 +200,18 @@ class MenuHelperTest extends TestCase
         $this->assertCount(1, $menu->getItems());
     }
 
+    public function testRegisterSupportsMenuAndHelperCallbackSignature(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest());
+
+        $menu = $menuHelper->register('main', static function ($menu, MenuHelper $helper): void {
+            $menu->addItem('Articles', '/articles');
+            $helper->has('main');
+        });
+
+        $this->assertCount(1, $menu->getItems());
+    }
+
     public function testRegisterCanRebuildExistingMenu(): void
     {
         $menuHelper = $this->createHelper(new ServerRequest());

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -15,6 +15,7 @@ use Menu\Renderer\BreadcrumbRenderer;
 use Menu\Resolver\AuthorizationResolver;
 use Menu\Resolver\ResolverCollection;
 use Menu\Resolver\ResolverContext;
+use Menu\Resolver\SectionResolver;
 use Menu\View\Helper\MenuHelper;
 
 class MenuHelperTest extends TestCase
@@ -88,8 +89,11 @@ class MenuHelperTest extends TestCase
         $currentItem = $menuHelper->getCurrentItem('main');
         $path = $menuHelper->extractPath($child);
 
-        $this->assertSame($child, $currentItem);
-        $this->assertSame([$parent, $child], $path);
+        $this->assertSame('View', $currentItem?->getLabel());
+        $this->assertSame(['Articles', 'View'], array_map(
+            static fn (ItemInterface $item): ?string => $item->getLabel(),
+            $path,
+        ));
     }
 
     public function testHelperLifecycleMethods(): void
@@ -172,8 +176,46 @@ class MenuHelperTest extends TestCase
             $menu->addItem('Articles', '/articles');
         });
 
+        $menuAgain = $menuHelper->register('main', static function ($menu): void {
+            $menu->addItem('Users', '/users');
+        });
+
         $this->assertSame($menu, $menuHelper->get('main'));
+        $this->assertSame($menuAgain, $menuHelper->get('main'));
         $this->assertCount(1, $menu->getItems());
+    }
+
+    public function testRenderDoesNotLeakResolverStateIntoStoredMenu(): void
+    {
+        $request = (new ServerRequest(['url' => '/articles']))
+            ->withAttribute('params', [
+                'controller' => 'Articles',
+                'action' => 'index',
+            ])
+            ->withUri((new ServerRequest())->getUri()->withPath('/articles'));
+        $menuHelper = $this->createHelper($request);
+
+        $menu = $menuHelper->create('main');
+        $menu->addItem('Admin', '/admin', ['data' => ['role' => 'admin']]);
+        $menu->addItem('Articles', '/articles', [
+            'data' => ['section' => ['controller' => 'Articles']],
+        ]);
+
+        $menuHelper->render('main', [
+            'resolver' => (new ResolverCollection())
+                ->add(new SectionResolver($request))
+                ->add(new AuthorizationResolver(static function (ItemInterface $item, ResolverContext $context): ?bool {
+                    if ($item->getData('role') === 'admin') {
+                        return false;
+                    }
+
+                    return null;
+                })),
+        ]);
+
+        $this->assertTrue($menu->getItems()[0]->isVisible());
+        $this->assertFalse($menu->getItems()[1]->isActive());
+        $this->assertFalse($menu->getItems()[1]->isExpanded());
     }
 
     public function testAuthorizationResolverAndDepthLimit(): void


### PR DESCRIPTION
## Summary

This follow-up fixes the concrete issues found after the big menu merge.

## What changed

- Made `PermissionResolver` support authorizer methods with varying `can()` signatures instead of always forcing four arguments.
- Fixed menu cloning/import so submenu metadata survives round-trips even when a submenu currently has no items.
- Switched helper resolver application to operate on a cloned menu so active/expanded/visibility state does not leak across repeated named-menu renders.
- Restored parent-chain integrity for cloned/imported submenu items by propagating owner items into existing submenu children.
- Made helper `register()` idempotent by default and only rebuild a menu when explicitly requested.
- Made `JsonRenderer` fail loudly on JSON encoding issues instead of silently returning an empty string.
- Improved `Bootstrap5Renderer` so branch and child links receive more usable Bootstrap-style attributes/classes.
- Added regression tests for state leakage, submenu round-tripping, parent-path preservation, and flexible permission resolver signatures.
