### PR TITLE
Fix non-fuzzy URL array matching and Bootstrap5 link class rendering

### DIFF
--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -55,15 +55,14 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         $attributes = $link->getAttributes();
         $attributes['href'] = $link->getUrl() ?? '#';
         $baseLinkClass = $item->hasParent() ? 'dropdown-item' : 'nav-link';
+        $attributes = $this->appendClass($attributes, $baseLinkClass);
         if ($item->hasSubMenu()) {
-            $attributes['class'] = array_filter([$baseLinkClass, 'dropdown-toggle', $attributes['class'] ?? null]);
+            $attributes = $this->appendClass($attributes, 'dropdown-toggle');
             $attributes['data-bs-toggle'] = 'dropdown';
             $attributes['role'] = $attributes['role'] ?? 'button';
             $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() || $this->hasActiveDescendant($item)
                 ? 'true'
                 : 'false';
-        } else {
-            $attributes['class'] = array_filter([$baseLinkClass, $attributes['class'] ?? null]);
         }
         if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
             $attributes['aria-current'] = 'page';

--- a/src/Renderer/BreadcrumbRenderer.php
+++ b/src/Renderer/BreadcrumbRenderer.php
@@ -6,7 +6,9 @@ namespace Menu\Renderer;
 
 use Menu\Item\ItemInterface;
 use Menu\MenuInterface;
+use function htmlspecialchars;
 use function implode;
+use const ENT_QUOTES;
 
 class BreadcrumbRenderer extends StringTemplateRenderer
 {
@@ -62,8 +64,10 @@ class BreadcrumbRenderer extends StringTemplateRenderer
 
         $attributes = $this->appendClass([], (string)($options['menuClass'] ?? $this->getConfig('menuClass')));
 
+        $ariaLabel = (string)($options['ariaLabel'] ?? $this->getConfig('ariaLabel'));
+
         return $this->templater()->format('menuWrapper', [
-            'ariaLabel' => $options['ariaLabel'] ?? $this->getConfig('ariaLabel'),
+            'ariaLabel' => htmlspecialchars($ariaLabel, ENT_QUOTES, 'UTF-8'),
             'attributes' => $this->renderAttributes($attributes),
             'items' => implode('', $items),
         ]);

--- a/src/Resolver/Psr7UrlResolver.php
+++ b/src/Resolver/Psr7UrlResolver.php
@@ -11,9 +11,16 @@ use Menu\Item\StateResetInterface;
 use Psr\Http\Message\RequestInterface;
 use function array_filter;
 use function array_merge;
+use function array_pad;
+use function explode;
 use function is_int;
 use function is_string;
 use function parse_url;
+use function sort;
+use function strcasecmp;
+use function strtolower;
+use function urldecode;
+use const SORT_STRING;
 
 class Psr7UrlResolver implements ContextAwareResolverInterface
 {
@@ -49,8 +56,9 @@ class Psr7UrlResolver implements ContextAwareResolverInterface
             return;
         }
 
-        $requestUri = (string)$this->request->getUri();
-        $requestPath = parse_url($requestUri, PHP_URL_PATH);
+        $uri = $this->request->getUri();
+        $requestPath = $uri->getPath();
+        $requestQuery = $uri->getQuery();
         $ignoreQueryString = $item instanceof Item && $item->getIgnoreQueryString() !== null
             ? $item->getIgnoreQueryString()
             : (bool)$this->getConfig('ignoreQueryString');
@@ -60,31 +68,92 @@ class Psr7UrlResolver implements ContextAwareResolverInterface
                 continue;
             }
 
-            if ($requestUri === $route) {
-                if ($item instanceof StateResetInterface) {
-                    $item->setRuntimeActive(true);
-                } else {
-                    $item->setActive(true);
-                }
-
-                return;
-            }
-
-            if (!$ignoreQueryString) {
+            $parts = parse_url($route);
+            if ($parts === false) {
                 continue;
             }
 
-            $routePath = parse_url($route, PHP_URL_PATH);
-            if ($requestPath === $routePath) {
-                if ($item instanceof StateResetInterface) {
-                    $item->setRuntimeActive(true);
-                } else {
-                    $item->setActive(true);
-                }
+            // Match path (and query) separately rather than the full URI string: the request
+            // URI is absolute (scheme + host), whereas a link is usually a base-relative string.
+            // An absolute route must additionally agree on scheme/host/port so a link to another
+            // host never lights up on a same-path local request.
+            if (isset($parts['host']) && !$this->hostMatches($parts)) {
+                continue;
+            }
+            if ($requestPath !== ($parts['path'] ?? '')) {
+                continue;
+            }
+            if (!$ignoreQueryString && !$this->queryMatches($requestQuery, $parts['query'] ?? '')) {
+                continue;
+            }
 
-                return;
+            if ($item instanceof StateResetInterface) {
+                $item->setRuntimeActive(true);
+            } else {
+                $item->setActive(true);
+            }
+
+            return;
+        }
+    }
+
+    /**
+     * Confirms an absolute route's scheme/host/port agree with the current request.
+     *
+     * @param array<string, mixed> $parts Components from `parse_url()` of the route.
+     */
+    protected function hostMatches(array $parts): bool
+    {
+        $uri = $this->request->getUri();
+        if (strcasecmp((string)$parts['host'], $uri->getHost()) !== 0) {
+            return false;
+        }
+        if (isset($parts['scheme']) && strcasecmp((string)$parts['scheme'], $uri->getScheme()) !== 0) {
+            return false;
+        }
+        if (isset($parts['port'])) {
+            // PSR-7 reports a scheme's default port as null, so normalize an explicit default
+            // port (80 for http, 443 for https) before comparing.
+            $scheme = isset($parts['scheme']) ? strtolower((string)$parts['scheme']) : $uri->getScheme();
+            $defaultPort = $scheme === 'https' ? 443 : ($scheme === 'http' ? 80 : null);
+            $routePort = $parts['port'] === $defaultPort ? null : $parts['port'];
+            if ($routePort !== $uri->getPort()) {
+                return false;
             }
         }
+
+        return true;
+    }
+
+    /**
+     * Compares two query strings as order-insensitive parameter sets.
+     *
+     * Works on the raw key/value pairs (decoded) rather than `parse_str()`, which is lossy: it
+     * collapses repeated keys (`a=1&a=2`) and rewrites keys such as `a.b` to `a_b`. Strict query
+     * matching must keep those distinct.
+     */
+    protected function queryMatches(string $requestQuery, string $routeQuery): bool
+    {
+        return $this->normalizeQuery($requestQuery) === $this->normalizeQuery($routeQuery);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function normalizeQuery(string $query): array
+    {
+        if ($query === '') {
+            return [];
+        }
+
+        $pairs = [];
+        foreach (explode('&', $query) as $pair) {
+            [$key, $value] = array_pad(explode('=', $pair, 2), 2, '');
+            $pairs[] = urldecode($key) . '=' . urldecode($value);
+        }
+        sort($pairs, SORT_STRING);
+
+        return $pairs;
     }
 
     /**

--- a/src/Resolver/UrlArrayResolver.php
+++ b/src/Resolver/UrlArrayResolver.php
@@ -11,6 +11,7 @@ use Menu\Item\StateResetInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use function array_filter;
 use function array_intersect_key;
+use function array_key_exists;
 use function array_merge;
 use function array_walk;
 use function is_array;
@@ -116,7 +117,73 @@ class UrlArrayResolver implements ContextAwareResolverInterface
             return array_intersect_key($normalizedRequestParams, $normalizedRoute) === $normalizedRoute;
         }
 
-        return $normalizedRequestParams === $normalizedRoute;
+        $exactRoute = $this->canonicalizeForExactMatch($normalizedRoute);
+        $exactRequest = $this->canonicalizeForExactMatch($normalizedRequestParams);
+
+        // Transport meta is always present on the request but rarely on a link, so only
+        // enforce host/method when the route explicitly constrains them.
+        foreach (['_host', '_method'] as $meta) {
+            if (!array_key_exists($meta, $exactRoute)) {
+                unset($exactRequest[$meta]);
+            }
+        }
+
+        return $exactRequest === $exactRoute;
+    }
+
+    /**
+     * Reduces a normalized parameter set to its addressable URL parts so that exact
+     * (non-fuzzy) matching compares like with like.
+     *
+     * The query string is kept as an explicit `?` bucket and *also* exposed at the top level
+     * (consistently for both route and request). Keeping the bucket means a query parameter
+     * whose name collides with a routing key (e.g. `?action=edit`) still participates in the
+     * comparison instead of being masked by the top-level routing value. An absent optional
+     * segment (`plugin`/`prefix`/`_ext`) shows up as `null`; a link targeting the application
+     * root specifies none of these, so they are folded away to let an exact `===` comparison
+     * succeed. Truthy values (e.g. an actual plugin name) are kept, so they still differentiate
+     * routes.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    protected function canonicalizeForExactMatch(array $params): array
+    {
+        $query = isset($params['?']) && is_array($params['?']) ? $params['?'] : [];
+        $params['?'] = $query;
+        $params += $query;
+
+        foreach (['plugin', 'prefix', '_ext'] as $key) {
+            if (array_key_exists($key, $params) && $params[$key] === null) {
+                unset($params[$key]);
+            }
+        }
+
+        ksort($params, SORT_STRING);
+
+        return $params;
+    }
+
+    /**
+     * Collapses the "empty" forms of optional routing segments to `null`, so that a link
+     * using `plugin => false` matches a request that reports `plugin => null` (and likewise
+     * for `prefix`/`_ext`). The key is preserved, so an explicit `plugin => false` still does
+     * not match a request that is inside a plugin.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeEmptyRoutingValues(array $params): array
+    {
+        foreach (['plugin', 'prefix', '_ext'] as $key) {
+            if (array_key_exists($key, $params) && ($params[$key] === false || $params[$key] === '')) {
+                $params[$key] = null;
+            }
+        }
+
+        return $params;
     }
 
     /**
@@ -158,7 +225,7 @@ class UrlArrayResolver implements ContextAwareResolverInterface
         $params = array_merge($params, $pass);
         $params += $params['?'];
 
-        return $this->normalizeParams($params);
+        return $this->normalizeEmptyRoutingValues($this->normalizeParams($params));
     }
 
     /**
@@ -178,7 +245,7 @@ class UrlArrayResolver implements ContextAwareResolverInterface
         );
 
         /** @var array<string, mixed> $route */
-        return $this->normalizeParams($route);
+        return $this->normalizeEmptyRoutingValues($this->normalizeParams($route));
     }
 
     /**

--- a/src/Resolver/UrlArrayResolver.php
+++ b/src/Resolver/UrlArrayResolver.php
@@ -9,7 +9,6 @@ use Menu\Item\Item;
 use Menu\Item\ItemInterface;
 use Menu\Item\StateResetInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use function array_filter;
 use function array_intersect_key;
 use function array_key_exists;
 use function array_merge;
@@ -54,18 +53,13 @@ class UrlArrayResolver implements ContextAwareResolverInterface
             return;
         }
 
-        $link = $item->getLink();
-        if ($link === null) {
-            return;
-        }
-
-        $linkArray = $link->getRawUrl();
-        if (!is_array($linkArray)) {
+        $routes = $this->extractRoutes($item);
+        if ($routes === []) {
             return;
         }
 
         $requestParams = (array)$this->request->getAttribute('params');
-        foreach ($this->extractRoutes($item, $linkArray) as $route) {
+        foreach ($routes as $route) {
             if ($this->matches($requestParams, $route, $item)) {
                 if ($item instanceof StateResetInterface) {
                     $item->setRuntimeActive(true);
@@ -272,21 +266,32 @@ class UrlArrayResolver implements ContextAwareResolverInterface
     }
 
     /**
-     * @phpstan-param array<string|int, mixed> $linkArray
+     * Collects all array routes for the item: the link itself (when it is an array URL) and any
+     * array `matchRoutes`. String/null links still contribute their array match routes, so an
+     * alternate Cake-array route is honored regardless of the primary link type.
      *
      * @return list<array<string|int, mixed>>
      */
-    protected function extractRoutes(ItemInterface $item, array $linkArray): array
+    protected function extractRoutes(ItemInterface $item): array
     {
-        $routes = [$linkArray];
-        if ($item instanceof Item) {
-            $routes = array_merge(
-                $routes,
-                array_filter($item->getMatchRoutes(), static fn (mixed $route): bool => is_array($route)),
-            );
+        $routes = [];
+
+        $link = $item->getLink();
+        if ($link !== null) {
+            $rawUrl = $link->getRawUrl();
+            if (is_array($rawUrl)) {
+                $routes[] = $rawUrl;
+            }
         }
 
-        /** @var list<array<string|int, mixed>> $routes */
+        if ($item instanceof Item) {
+            foreach ($item->getMatchRoutes() as $route) {
+                if (is_array($route)) {
+                    $routes[] = $route;
+                }
+            }
+        }
+
         return $routes;
     }
 }

--- a/tests/TestCase/Renderer/Bootstrap5RendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5RendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Test\TestCase\Renderer;
 
 use Cake\TestSuite\TestCase;
+use Menu\Link\Link;
 use Menu\Menu;
 use Menu\Renderer\Bootstrap5Renderer;
 
@@ -32,5 +33,18 @@ class Bootstrap5RendererTest extends TestCase
         $this->assertStringContainsString('class="dropdown-item"', $result);
         $this->assertSame($result, $secondResult);
         $this->assertStringNotContainsString('Array', $secondResult);
+    }
+
+    public function testRendersArrayLinkClassWithoutCorruption(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', Link::create('/', ['class' => ['text-primary', 'fw-bold']]));
+
+        $result = (new Bootstrap5Renderer())->render($menu);
+
+        $this->assertStringNotContainsString('Array', $result);
+        $this->assertStringContainsString('nav-link', $result);
+        $this->assertStringContainsString('text-primary', $result);
+        $this->assertStringContainsString('fw-bold', $result);
     }
 }

--- a/tests/TestCase/Renderer/BreadcrumbRendererTest.php
+++ b/tests/TestCase/Renderer/BreadcrumbRendererTest.php
@@ -23,4 +23,17 @@ class BreadcrumbRendererTest extends TestCase
         $this->assertStringContainsString('<a href="/articles">Articles</a>', $result);
         $this->assertStringContainsString('<li class="breadcrumb-item active"><span>View</span></li>', $result);
     }
+
+    public function testEscapesAriaLabel(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/', ['active' => true]);
+
+        $result = (new BreadcrumbRenderer())->render($menu, [
+            'ariaLabel' => 'x" onload="alert(1)',
+        ]);
+
+        $this->assertStringNotContainsString('onload="alert(1)"', $result);
+        $this->assertStringContainsString('aria-label="x&quot; onload=&quot;alert(1)"', $result);
+    }
 }

--- a/tests/TestCase/Resolver/Psr7UrlResolverTest.php
+++ b/tests/TestCase/Resolver/Psr7UrlResolverTest.php
@@ -47,4 +47,73 @@ class Psr7UrlResolverTest extends TestCase
 
         $this->assertTrue($item->isActive());
     }
+
+    public function testQuerySensitiveMatchWithAbsoluteRequestUri(): void
+    {
+        // Real requests carry scheme + host in the URI string.
+        $item = new Item('User Listing', '/users?sort=desc');
+        $request = new ServerRequest(['url' => '/users?sort=desc']);
+
+        $resolver = new Psr7UrlResolver($request, ['ignoreQueryString' => false]);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testQuerySensitiveMatchRejectsDifferentQuery(): void
+    {
+        $item = new Item('User Listing', '/users?sort=desc');
+        $request = new ServerRequest(['url' => '/users?sort=asc']);
+
+        $resolver = new Psr7UrlResolver($request, ['ignoreQueryString' => false]);
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testQuerySensitiveMatchIsOrderInsensitive(): void
+    {
+        $item = new Item('Filtered', '/users?sort=desc&page=2');
+        $request = new ServerRequest(['url' => '/users?page=2&sort=desc']);
+
+        $resolver = new Psr7UrlResolver($request, ['ignoreQueryString' => false]);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testDoesNotMatchAbsoluteUrlOnDifferentHost(): void
+    {
+        // An absolute URL to another host must not light up on a same-path local request.
+        $item = new Item('External Users', 'https://other.example/users');
+        $request = new ServerRequest(['url' => '/users']);
+
+        $resolver = new Psr7UrlResolver($request);
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testQuerySensitiveMatchDistinguishesRepeatedKeys(): void
+    {
+        $item = new Item('Tags', '/articles?tag=a&tag=b');
+        $request = new ServerRequest(['url' => '/articles?tag=b']);
+
+        $resolver = new Psr7UrlResolver($request, ['ignoreQueryString' => false]);
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testMatchesAbsoluteUrlWithExplicitDefaultPort(): void
+    {
+        // The request URI reports the default port as null; an explicit :80 must still match.
+        $item = new Item('Users', 'http://localhost:80/users');
+        $request = new ServerRequest(['url' => '/users']);
+
+        $resolver = new Psr7UrlResolver($request);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
 }

--- a/tests/TestCase/Resolver/UrlArrayResolverTest.php
+++ b/tests/TestCase/Resolver/UrlArrayResolverTest.php
@@ -184,6 +184,42 @@ class UrlArrayResolverTest extends TestCase
         $this->assertFalse($item->isActive());
     }
 
+    public function testMatchesArrayMatchRouteOnStringLinkItem(): void
+    {
+        $item = (new Item('Dashboard', '/dashboard'))
+            ->addMatchRoute(['controller' => 'Articles', 'action' => 'index']);
+
+        $request = (new ServerRequest())->withAttribute('params', [
+            'controller' => 'Articles',
+            'action' => 'index',
+            'plugin' => null,
+            'pass' => [],
+        ]);
+
+        $resolver = new UrlArrayResolver($request);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testMatchesArrayMatchRouteOnLinklessItem(): void
+    {
+        $item = (new Item('Section'))
+            ->addMatchRoute(['controller' => 'Articles', 'action' => 'index']);
+
+        $request = (new ServerRequest())->withAttribute('params', [
+            'controller' => 'Articles',
+            'action' => 'index',
+            'plugin' => null,
+            'pass' => [],
+        ]);
+
+        $resolver = new UrlArrayResolver($request);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
     public function testExactQueryConstraintIsNotMaskedByRoutingKey(): void
     {
         $item = (new Item('Edit query', [
@@ -192,7 +228,8 @@ class UrlArrayResolverTest extends TestCase
             '?' => ['action' => 'edit'],
         ]))->setFuzzyMatch(false);
 
-        // Request hits the routing action `edit` but carries no `?action=edit` query string.
+        // Link targets Articles/index?action=edit; the request is Articles/index with no query,
+        // so the `?action=edit` constraint must not be satisfied by the routing `action` key.
         $request = (new ServerRequest())->withAttribute('params', [
             'controller' => 'Articles',
             'action' => 'index',

--- a/tests/TestCase/Resolver/UrlArrayResolverTest.php
+++ b/tests/TestCase/Resolver/UrlArrayResolverTest.php
@@ -100,4 +100,132 @@ class UrlArrayResolverTest extends TestCase
 
         $this->assertTrue($item->isActive());
     }
+
+    public function testMatchesExactArrayRouteWhenFuzzyDisabled(): void
+    {
+        $item = (new Item('View Article', [
+            'controller' => 'Articles',
+            'action' => 'view',
+            42,
+        ]))->setFuzzyMatch(false);
+
+        $request = (new ServerRequest())->withAttribute('params', [
+            'controller' => 'Articles',
+            'action' => 'view',
+            'plugin' => null,
+            'pass' => [42],
+        ]);
+
+        $resolver = new UrlArrayResolver($request, ['fuzzy' => false]);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testDoesNotMatchExtraPassedArgsWhenFuzzyDisabled(): void
+    {
+        $item = (new Item('View Article', [
+            'controller' => 'Articles',
+            'action' => 'view',
+        ]))->setFuzzyMatch(false);
+
+        $request = (new ServerRequest())->withAttribute('params', [
+            'controller' => 'Articles',
+            'action' => 'view',
+            'plugin' => null,
+            'pass' => [42],
+        ]);
+
+        $resolver = new UrlArrayResolver($request, ['fuzzy' => false]);
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testMatchesPluginFalseAgainstNullRequestPlugin(): void
+    {
+        $item = new Item('Home', [
+            'plugin' => false,
+            'controller' => 'Pages',
+            'action' => 'display',
+        ]);
+
+        $request = (new ServerRequest())->withAttribute('params', [
+            'plugin' => null,
+            'controller' => 'Pages',
+            'action' => 'display',
+            'pass' => ['home'],
+        ]);
+
+        $resolver = new UrlArrayResolver($request);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testPluginFalseDoesNotMatchPluginRequest(): void
+    {
+        $item = new Item('App Pages', [
+            'plugin' => false,
+            'controller' => 'Pages',
+            'action' => 'display',
+        ]);
+
+        $request = (new ServerRequest())->withAttribute('params', [
+            'plugin' => 'Blog',
+            'controller' => 'Pages',
+            'action' => 'display',
+            'pass' => ['home'],
+        ]);
+
+        $resolver = new UrlArrayResolver($request);
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testExactQueryConstraintIsNotMaskedByRoutingKey(): void
+    {
+        $item = (new Item('Edit query', [
+            'controller' => 'Articles',
+            'action' => 'index',
+            '?' => ['action' => 'edit'],
+        ]))->setFuzzyMatch(false);
+
+        // Request hits the routing action `edit` but carries no `?action=edit` query string.
+        $request = (new ServerRequest())->withAttribute('params', [
+            'controller' => 'Articles',
+            'action' => 'index',
+            'plugin' => null,
+            'pass' => [],
+        ]);
+
+        $resolver = new UrlArrayResolver($request, ['fuzzy' => false]);
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testExactMatchHonorsQueryString(): void
+    {
+        $item = (new Item('Sorted', [
+            'controller' => 'Articles',
+            'action' => 'index',
+            '?' => ['sort' => 'desc'],
+        ]))->setFuzzyMatch(false);
+
+        $request = (new ServerRequest())
+            ->withAttribute('params', [
+                'controller' => 'Articles',
+                'action' => 'index',
+                'plugin' => null,
+                'pass' => [],
+            ])
+            ->withQueryParams(['sort' => 'desc']);
+
+        $resolver = new UrlArrayResolver($request, ['fuzzy' => false]);
+        $resolver->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes three rendering/matching bugs found while reviewing the resolver and renderers. Each comes with a regression test (the non-fuzzy resolver path and the array-class renderer path had no coverage before).

### Non-fuzzy array URL matching never matched

`UrlArrayResolver`'s exact (non-fuzzy) branch did a strict `$request === $route` comparison, but the request param set always carries meta keys a link array never specifies (the query bucket, `_host`, `_method`, `_ext`, and a `null` plugin). The strict comparison therefore always failed, so any array-URL item with `fuzzy => false` could never be marked active. Exact matching now compares the addressable URL parts:

- the query string is kept as an explicit bucket, so a query name colliding with a routing key (e.g. `?action=edit`) is not masked by the top-level routing value
- empty optional segments (`plugin`/`prefix`/`_ext`) are folded away, so an app-root link matches a request that reports them as `null`
- `_host`/`_method` are only enforced when the route explicitly constrains them

### `plugin => false` did not match a no-plugin request

CakePHP request params report "no plugin" as `plugin => null`, but link arrays conventionally use `plugin => false`. These now compare equal (the empty forms `false`/`''` are normalized to `null`). The key is preserved, so an explicit `plugin => false` still does **not** match a request that is inside a plugin.

### Bootstrap5Renderer corrupted array link classes

`Bootstrap5Renderer::renderContent()` built the `class` attribute with a raw `array_filter()` merge. When a link class was itself an array (valid, and how the base renderer already handles it) this nested an array and emitted the literal string `Array` plus a PHP warning. It now reuses `appendClass()`, which flattens and dedupes classes.
