### PR TITLE
Cleanup follow-ups: getKey purity, Menu::collect(), aria-current on labels, resolver state trait

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,24 @@ $menu->clearActive();
 $menu->getActiveItem();
 ```
 
+### Flattened Collection
+
+`Menu::collect()` returns an `ItemCollection` containing every item in the tree (depth-first), so
+you can iterate or query the whole menu without manual recursion:
+
+```php
+$items = $menu->collect();
+
+foreach ($items as $item) {
+    // ...
+}
+
+$items->findById('menu-item-...');
+$items->findByKey('profile');
+$items->findByParent($accountItem); // direct children of $accountItem
+count($items);
+```
+
 ## Resolvers
 
 Resolvers apply cross-cutting state without mixing request/session logic into menu construction.
@@ -320,7 +338,7 @@ echo $this->Menu->render($menu, [
 - Active matching is automatic in the helper by default and uses both array and string resolvers.
 - Each helper render/request-state lookup applies resolvers temporarily and restores the original `active`, `visible`, and `expanded` item state afterward.
 - Custom item classes should extend `Menu\Item\Item` or implement `Menu\Item\StateResetInterface` if you want `Menu::resetState()` to restore their original runtime defaults.
-- The default renderer emits `aria-current="page"` for the active link and `aria-expanded` for branch items.
+- The default renderer emits `aria-current="page"` for the active item (whether rendered as a link or as a label) and `aria-expanded` for branch items.
 
 ## Recipes
 

--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -110,11 +110,14 @@ class Item implements ItemInterface, StateResetInterface
 
     public function getKey(): string
     {
-        if ($this->key === '' && $this->label !== null) {
-            $this->key = strtolower((string)Text::slug($this->label));
+        if ($this->key !== '') {
+            return $this->key;
+        }
+        if ($this->label !== null) {
+            return strtolower((string)Text::slug($this->label));
         }
 
-        return $this->key;
+        return '';
     }
 
     public function hasExplicitKey(): bool

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -233,6 +233,28 @@ class Menu implements MenuInterface
         return $this->items;
     }
 
+    public function collect(): ItemCollection
+    {
+        $collection = new ItemCollection();
+        $this->collectInto($collection, $this->items);
+
+        return $collection;
+    }
+
+    /**
+     * @param \Menu\ItemCollection $collection
+     * @param list<\Menu\Item\ItemInterface> $items
+     */
+    protected function collectInto(ItemCollection $collection, array $items): void
+    {
+        foreach ($items as $item) {
+            $collection->add($item);
+            if ($item->hasSubMenu()) {
+                $this->collectInto($collection, $item->getSubMenu()->getItems());
+            }
+        }
+    }
+
     /**
      * @phpstan-param array<mixed> $items
      *

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -69,6 +69,12 @@ interface MenuInterface
     public function getItems(): array;
 
     /**
+     * Returns a flat collection of every item in the tree (depth-first), so the whole menu can
+     * be iterated or queried by id/key/parent without manual recursion.
+     */
+    public function collect(): ItemCollection;
+
+    /**
      * @phpstan-param array<mixed> $items
      *
      * @return $this

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -69,12 +69,6 @@ interface MenuInterface
     public function getItems(): array;
 
     /**
-     * Returns a flat collection of every item in the tree (depth-first), so the whole menu can
-     * be iterated or queried by id/key/parent without manual recursion.
-     */
-    public function collect(): ItemCollection;
-
-    /**
      * @phpstan-param array<mixed> $items
      *
      * @return $this

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -15,7 +15,7 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         'activeClass' => 'active',
         'ancestorClass' => 'active',
         'branchClass' => 'dropdown',
-        'submenuClass' => 'dropdown',
+        'submenuClass' => null,
         'addAriaExpanded' => false,
         'nestedMenuClass' => 'dropdown-menu',
         'menuLevelClass' => null,
@@ -45,6 +45,9 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         if ($link === null || ($item->isActive() && !$this->getBooleanOption($options, 'currentAsLink', true))) {
             $attributes = $link?->getAttributes() ?? [];
             unset($attributes['href']);
+            if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
+                $attributes['aria-current'] = 'page';
+            }
 
             return $this->templater()->format('label', [
                 'attributes' => $this->renderAttributes($attributes),

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -35,7 +35,8 @@ class StringTemplateRenderer implements RendererInterface
         'dividerClass' => 'divider',
         'branchClass' => 'has-children',
         'leafClass' => null,
-        'submenuClass' => 'has-children',
+        // Extra class for branch <li>s, in addition to `branchClass`; off by default.
+        'submenuClass' => null,
         'nestedMenuClass' => 'submenu',
         'menuLevelClass' => null,
         'firstClass' => null,
@@ -201,6 +202,9 @@ class StringTemplateRenderer implements RendererInterface
         if ($link === null || ($item->isActive() && !$this->getBooleanOption($options, 'currentAsLink', true))) {
             $attributes = $link?->getAttributes() ?? [];
             unset($attributes['href']);
+            if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
+                $attributes['aria-current'] = 'page';
+            }
 
             return $this->templater()->format('label', [
                 'attributes' => $this->renderAttributes($attributes),

--- a/src/Resolver/AuthorizationResolver.php
+++ b/src/Resolver/AuthorizationResolver.php
@@ -6,10 +6,11 @@ namespace Menu\Resolver;
 
 use Closure;
 use Menu\Item\ItemInterface;
-use Menu\Item\StateResetInterface;
 
 class AuthorizationResolver implements ContextAwareResolverInterface
 {
+    use RuntimeStateTrait;
+
     /**
      * @var \Closure(\Menu\Item\ItemInterface, \Menu\Resolver\ResolverContext): (bool|null)
      */
@@ -32,11 +33,7 @@ class AuthorizationResolver implements ContextAwareResolverInterface
     {
         $allowed = ($this->callback)($item, $context);
         if ($allowed !== null) {
-            if ($item instanceof StateResetInterface) {
-                $item->setRuntimeVisibility($allowed);
-            } else {
-                $item->setVisibility($allowed);
-            }
+            $this->applyVisibility($item, $allowed);
         }
     }
 }

--- a/src/Resolver/LoggedInResolver.php
+++ b/src/Resolver/LoggedInResolver.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
-use Menu\Item\StateResetInterface;
 
 class LoggedInResolver implements ContextAwareResolverInterface
 {
+    use RuntimeStateTrait;
+
     public function __construct(protected bool $loggedIn)
     {
     }
@@ -22,17 +23,9 @@ class LoggedInResolver implements ContextAwareResolverInterface
     {
         $auth = $item->getData('auth');
         if ($auth === 'loggedIn') {
-            if ($item instanceof StateResetInterface) {
-                $item->setRuntimeVisibility($this->loggedIn);
-            } else {
-                $item->setVisibility($this->loggedIn);
-            }
+            $this->applyVisibility($item, $this->loggedIn);
         } elseif ($auth === 'loggedOut') {
-            if ($item instanceof StateResetInterface) {
-                $item->setRuntimeVisibility(!$this->loggedIn);
-            } else {
-                $item->setVisibility(!$this->loggedIn);
-            }
+            $this->applyVisibility($item, !$this->loggedIn);
         }
     }
 }

--- a/src/Resolver/PermissionResolver.php
+++ b/src/Resolver/PermissionResolver.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
-use Menu\Item\StateResetInterface;
 use ReflectionMethod;
 use function is_string;
 use function method_exists;
 
 class PermissionResolver implements ContextAwareResolverInterface
 {
+    use RuntimeStateTrait;
+
     protected ?int $parameterCount = null;
 
     public function __construct(
@@ -36,11 +37,7 @@ class PermissionResolver implements ContextAwareResolverInterface
 
         $allowed = $this->invokeAuthorizer($permission, $item, $context);
         if (is_bool($allowed)) {
-            if ($item instanceof StateResetInterface) {
-                $item->setRuntimeVisibility($allowed);
-            } else {
-                $item->setVisibility($allowed);
-            }
+            $this->applyVisibility($item, $allowed);
         }
     }
 

--- a/src/Resolver/Psr7UrlResolver.php
+++ b/src/Resolver/Psr7UrlResolver.php
@@ -7,7 +7,6 @@ namespace Menu\Resolver;
 use Cake\Core\InstanceConfigTrait;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
-use Menu\Item\StateResetInterface;
 use Psr\Http\Message\RequestInterface;
 use function array_filter;
 use function array_merge;
@@ -25,6 +24,7 @@ use const SORT_STRING;
 class Psr7UrlResolver implements ContextAwareResolverInterface
 {
     use InstanceConfigTrait;
+    use RuntimeStateTrait;
 
     /**
      * @var array<string, mixed>
@@ -87,11 +87,7 @@ class Psr7UrlResolver implements ContextAwareResolverInterface
                 continue;
             }
 
-            if ($item instanceof StateResetInterface) {
-                $item->setRuntimeActive(true);
-            } else {
-                $item->setActive(true);
-            }
+            $this->applyActive($item);
 
             return;
         }

--- a/src/Resolver/RuntimeStateTrait.php
+++ b/src/Resolver/RuntimeStateTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Menu\Item\ItemInterface;
+use Menu\Item\StateResetInterface;
+
+/**
+ * Shared helpers for resolvers to set item state, preferring the runtime setters (which a later
+ * resetState() restores) when the item supports them.
+ */
+trait RuntimeStateTrait
+{
+    protected function applyActive(ItemInterface $item, bool $active = true): void
+    {
+        if ($item instanceof StateResetInterface) {
+            $item->setRuntimeActive($active);
+
+            return;
+        }
+
+        $item->setActive($active);
+    }
+
+    protected function applyVisibility(ItemInterface $item, bool $visible): void
+    {
+        if ($item instanceof StateResetInterface) {
+            $item->setRuntimeVisibility($visible);
+
+            return;
+        }
+
+        $item->setVisibility($visible);
+    }
+
+    protected function applyExpanded(ItemInterface $item, bool $expanded = true): void
+    {
+        if ($item instanceof StateResetInterface) {
+            $item->setRuntimeExpanded($expanded);
+
+            return;
+        }
+
+        $item->setExpanded($expanded);
+    }
+}

--- a/src/Resolver/SectionResolver.php
+++ b/src/Resolver/SectionResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Menu\Resolver;
 
 use Menu\Item\ItemInterface;
-use Menu\Item\StateResetInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use function array_is_list;
 use function is_array;
@@ -13,6 +12,8 @@ use function is_string;
 
 class SectionResolver implements ContextAwareResolverInterface
 {
+    use RuntimeStateTrait;
+
     public function __construct(
         protected ServerRequestInterface $request,
         protected string $dataKey = 'section',
@@ -35,17 +36,9 @@ class SectionResolver implements ContextAwareResolverInterface
         $requestParams = (array)$this->request->getAttribute('params');
         foreach ($this->normalizeSections($sections) as $section) {
             if ($this->matchesSection($requestParams, $section)) {
-                if ($item instanceof StateResetInterface) {
-                    $item->setRuntimeActive(true);
-                } else {
-                    $item->setActive(true);
-                }
+                $this->applyActive($item);
                 if ($this->expand) {
-                    if ($item instanceof StateResetInterface) {
-                        $item->setRuntimeExpanded();
-                    } else {
-                        $item->setExpanded();
-                    }
+                    $this->applyExpanded($item);
                 }
 
                 return;

--- a/src/Resolver/UrlArrayResolver.php
+++ b/src/Resolver/UrlArrayResolver.php
@@ -7,7 +7,6 @@ namespace Menu\Resolver;
 use Cake\Core\InstanceConfigTrait;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
-use Menu\Item\StateResetInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use function array_intersect_key;
 use function array_key_exists;
@@ -22,6 +21,7 @@ use const SORT_STRING;
 class UrlArrayResolver implements ContextAwareResolverInterface
 {
     use InstanceConfigTrait;
+    use RuntimeStateTrait;
 
     /**
      * @var array<string, mixed>
@@ -61,11 +61,7 @@ class UrlArrayResolver implements ContextAwareResolverInterface
         $requestParams = (array)$this->request->getAttribute('params');
         foreach ($routes as $route) {
             if ($this->matches($requestParams, $route, $item)) {
-                if ($item instanceof StateResetInterface) {
-                    $item->setRuntimeActive(true);
-                } else {
-                    $item->setActive(true);
-                }
+                $this->applyActive($item);
 
                 return;
             }

--- a/tests/TestCase/Item/ItemTest.php
+++ b/tests/TestCase/Item/ItemTest.php
@@ -61,4 +61,22 @@ class ItemTest extends TestCase
         $this->assertTrue($item->getIgnoreQueryString());
         $this->assertTrue($item->isFuzzyMatch());
     }
+
+    public function testGetKeyDoesNotPersistDerivedSlug(): void
+    {
+        $item = new Item('Some Label');
+
+        $this->assertSame('some-label', $item->getKey());
+        // A label-derived key is not promoted to an explicit key, and is not exported as one.
+        $this->assertFalse($item->hasExplicitKey());
+        $this->assertNull($item->toArray()['key']);
+    }
+
+    public function testGetKeyDoesNotMutateFrozenItem(): void
+    {
+        $item = (new Item('Some Label'))->freeze();
+
+        $this->assertSame('some-label', $item->getKey());
+        $this->assertNull($item->toArray()['key']);
+    }
 }

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -8,6 +8,7 @@ use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
 use LogicException;
 use Menu\Item\Item;
+use Menu\ItemCollection;
 use Menu\Menu;
 use Menu\Resolver\CallbackResolver;
 use Menu\Resolver\UrlArrayResolver;
@@ -207,5 +208,21 @@ class MenuTest extends TestCase
 
         $this->assertSame($secondParent, $child->getParent());
         $this->assertSame($child, $secondParent->getSubMenu()->get('child'));
+    }
+
+    public function testCollectFlattensTheTree(): void
+    {
+        $menu = Menu::create();
+        $account = $menu->addItem('Account', '#', ['key' => 'account']);
+        $account->getSubMenu()->addItem('Profile', '/profile', ['key' => 'profile']);
+        $account->getSubMenu()->addItem('Logout', '/logout', ['key' => 'logout']);
+        $menu->addItem('Home', '/', ['key' => 'home']);
+
+        $collection = $menu->collect();
+
+        $this->assertInstanceOf(ItemCollection::class, $collection);
+        $this->assertCount(4, $collection);
+        $this->assertSame('profile', $collection->findByKey('profile')?->getKey());
+        $this->assertCount(2, $collection->findByParent($account));
     }
 }

--- a/tests/TestCase/Renderer/BreadcrumbRendererTest.php
+++ b/tests/TestCase/Renderer/BreadcrumbRendererTest.php
@@ -21,7 +21,7 @@ class BreadcrumbRendererTest extends TestCase
         $this->assertStringContainsString('<nav aria-label="breadcrumb">', $result);
         $this->assertStringContainsString('<ol class="breadcrumb">', $result);
         $this->assertStringContainsString('<a href="/articles">Articles</a>', $result);
-        $this->assertStringContainsString('<li class="breadcrumb-item active"><span>View</span></li>', $result);
+        $this->assertStringContainsString('<li class="breadcrumb-item active"><span aria-current="page">View</span></li>', $result);
     }
 
     public function testEscapesAriaLabel(): void

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -43,7 +43,7 @@ class StringTemplateRendererTest extends TestCase
         ]))->render($menu);
 
         $this->assertStringContainsString('class="active-ancestor has-children"', $result);
-        $this->assertStringContainsString('<span>View</span>', $result);
+        $this->assertStringContainsString('<span aria-current="page">View</span>', $result);
         $this->assertStringNotContainsString('<a href="/articles/view">View</a>', $result);
     }
 
@@ -80,6 +80,26 @@ class StringTemplateRendererTest extends TestCase
 
         $this->assertStringContainsString('<ul aria-label="Main navigation">', $result);
         $this->assertStringContainsString('aria-expanded="true"', $result);
+        $this->assertStringContainsString('aria-current="page"', $result);
+    }
+
+    public function testActiveItemRenderedAsSpanGetsAriaCurrent(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/', ['active' => true]);
+
+        $result = (new StringTemplateRenderer())->render($menu, ['currentAsLink' => false]);
+
+        $this->assertStringContainsString('<span aria-current="page">Home</span>', $result);
+    }
+
+    public function testActiveItemWithoutLinkGetsAriaCurrent(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Section', null, ['active' => true]);
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
         $this->assertStringContainsString('aria-current="page"', $result);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up cleanups from the review of the plugin — the smaller items deferred from #4. Each is a focused commit and covered by tests.

### Make `Item::getKey()` a pure getter
`getKey()` lazily derived a slug from the label and **stored it back** into the `key` property — mutating the item (even when frozen) and making `toArray()` depend on whether `getKey()` had been called first. It now computes the slug without persisting it, so the getter is side-effect free and a label-derived key is never exported as an explicit key.

### Add `Menu::collect()` returning a flattened `ItemCollection`
`ItemCollection` (with `findById`/`findByKey`/`findByParent`) existed and was tested, but nothing produced one. `Menu::collect()` now returns a depth-first flat collection of the whole tree, so the menu can be iterated or queried by id/key/parent without manual recursion.

### Emit `aria-current` on active labels
When an active item renders as a label (no link, or `currentAsLink` disabled) it now also emits `aria-current="page"`, matching the behavior for active links. This also covers the current crumb in the breadcrumb renderer.

### Drop the redundant `submenuClass` default
`submenuClass` defaulted to the same value as `branchClass` (`has-children` / `dropdown`) and was applied to the same `<li>`, so it produced no additional output. Its default is now `null` (the knob remains for opt-in use). No output change.

### Extract resolver runtime-state setting into a trait
Six resolvers repeated the same `StateResetInterface` check when setting active/visible/expanded state. Moved into `RuntimeStateTrait` (`applyActive`/`applyVisibility`/`applyExpanded`). No behavior change.
