### PR TITLE
Add additionalResolvers and hideEmptyBranches options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -261,6 +261,25 @@ $menu->resolve(
 );
 ```
 
+### Adding Resolvers to the Defaults
+
+Passing a `resolver` replaces the built-in URL resolvers (so you lose automatic active-state
+matching). To **keep** the defaults and add your own (for example a visibility resolver), use
+`additionalResolvers` instead — they run after the URL resolvers:
+
+```php
+use Menu\Item\ItemInterface;
+use Menu\Resolver\AuthorizationResolver;
+
+echo $this->Menu->render('main', [
+    'additionalResolvers' => [
+        new AuthorizationResolver(static function (ItemInterface $item): ?bool {
+            return $item->getData('adminOnly') ? $isAdmin : null;
+        }),
+    ],
+]);
+```
+
 ### Depth-Limited Resolution
 
 When rendering through the helper, you can limit how deep automatic URL resolution should scan:
@@ -283,6 +302,21 @@ You can also fetch the resolved active item and extract its path:
 $current = $this->Menu->getCurrentItem('main');
 $path = $current ? $this->Menu->extractPath($current) : [];
 ```
+
+### Hiding Empty Branches
+
+When a resolver hides all of a branch's children (for example access filtering), the parent would
+otherwise render as an empty dropdown. Enable `hideEmptyBranches` to skip any branch with no
+visible, renderable descendants:
+
+```php
+echo $this->Menu->render('main', [
+    'hideEmptyBranches' => true,
+]);
+```
+
+This looks at child *visibility*, not the `depth` cutoff: a branch with visible children is still a
+valid top-level entry when its submenu is truncated by `depth`, so it is kept.
 
 ### Breadcrumb Integration
 

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -257,6 +257,10 @@ class StringTemplateRenderer implements RendererInterface
             if (!$child->isVisible()) {
                 continue;
             }
+            if ($child instanceof SelfRendererInterface) {
+                // A self-rendering item always emits markup, regardless of its submenu.
+                return true;
+            }
             if (!$child->hasSubMenu()) {
                 return true;
             }

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -37,6 +37,7 @@ class StringTemplateRenderer implements RendererInterface
         'leafClass' => null,
         // Extra class for branch <li>s, in addition to `branchClass`; off by default.
         'submenuClass' => null,
+        'hideEmptyBranches' => false,
         'nestedMenuClass' => 'submenu',
         'menuLevelClass' => null,
         'firstClass' => null,
@@ -159,6 +160,13 @@ class StringTemplateRenderer implements RendererInterface
 
         $attributes = $item->getAttributes();
         $hasSubMenu = $item->hasSubMenu();
+        if (
+            $hasSubMenu
+            && $this->getBooleanOption($options, 'hideEmptyBranches', false)
+            && !$this->hasRenderableChild($item, $options)
+        ) {
+            return '';
+        }
         if ($item->isActive()) {
             $attributes = $this->appendConfiguredClass($attributes, $options, 'activeClass');
         } elseif ($this->hasActiveDescendant($item)) {
@@ -233,6 +241,31 @@ class StringTemplateRenderer implements RendererInterface
         }
 
         return htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
+     * Whether a branch has at least one descendant that would actually render, honoring
+     * `hideEmptyBranches` recursively (so a branch containing only hidden/empty branches counts
+     * as empty too).
+     *
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function hasRenderableChild(ItemInterface $item, array $options): bool
+    {
+        $hideEmptyBranches = $this->getBooleanOption($options, 'hideEmptyBranches', false);
+        foreach ($item->getSubMenu()->getItems() as $child) {
+            if (!$child->isVisible()) {
+                continue;
+            }
+            if (!$child->hasSubMenu()) {
+                return true;
+            }
+            if (!$hideEmptyBranches || $this->hasRenderableChild($child, $options)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function hasActiveDescendant(ItemInterface $item): bool

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -402,6 +402,8 @@ class MenuHelper extends Helper
 
     /**
      * @phpstan-param array<string, mixed> $options
+     *
+     * @throws \InvalidArgumentException When `additionalResolvers` contains a non-resolver entry.
      */
     protected function createDefaultResolver(array $options): ResolverCollectionInterface
     {
@@ -422,8 +424,15 @@ class MenuHelper extends Helper
             ));
 
         $additional = $options['additionalResolvers'] ?? [];
-        if (is_array($additional) && $additional !== []) {
-            $collection->addMany($additional);
+        if (is_array($additional)) {
+            foreach ($additional as $resolver) {
+                if (!$resolver instanceof ResolverInterface) {
+                    throw new InvalidArgumentException(
+                        'Each additionalResolvers entry must implement ' . ResolverInterface::class . '.',
+                    );
+                }
+                $collection->add($resolver);
+            }
         }
 
         return $collection;

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -405,7 +405,7 @@ class MenuHelper extends Helper
      */
     protected function createDefaultResolver(array $options): ResolverCollectionInterface
     {
-        return (new ResolverCollection())
+        $collection = (new ResolverCollection())
             ->add(new UrlArrayResolver(
                 $this->getView()->getRequest(),
                 [
@@ -420,6 +420,13 @@ class MenuHelper extends Helper
                     'maxDepth' => $options['resolveDepth'] ?? null,
                 ],
             ));
+
+        $additional = $options['additionalResolvers'] ?? [];
+        if (is_array($additional) && $additional !== []) {
+            $collection->addMany($additional);
+        }
+
+        return $collection;
     }
 
     /**

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Menu\Test\TestCase\Renderer;
 
 use Cake\TestSuite\TestCase;
+use Menu\Item\Item;
+use Menu\Item\SelfRendererInterface;
 use Menu\Menu;
 use Menu\Renderer\StringTemplateRenderer;
 
@@ -124,6 +126,43 @@ class StringTemplateRendererTest extends TestCase
 
         $result = (new StringTemplateRenderer())->render($menu);
 
+        $this->assertStringContainsString('Admin', $result);
+    }
+
+    public function testHideEmptyBranchesRecursesThroughNestedBranches(): void
+    {
+        $menu = Menu::create();
+        $admin = $menu->addItem('Admin', '#');
+        $settings = $admin->getSubMenu()->addItem('Settings', '#');
+        $settings->getSubMenu()->addItem('Users', '/admin/users')->setVisibility(false);
+        $reports = $menu->addItem('Reports', '#');
+        $reports->getSubMenu()->addItem('Daily', '/reports/daily');
+
+        $result = (new StringTemplateRenderer())->render($menu, ['hideEmptyBranches' => true]);
+
+        $this->assertStringNotContainsString('Admin', $result);
+        $this->assertStringNotContainsString('Settings', $result);
+        $this->assertStringContainsString('Reports', $result);
+        $this->assertStringContainsString('Daily', $result);
+    }
+
+    public function testHideEmptyBranchesKeepsSelfRenderingChild(): void
+    {
+        $menu = Menu::create();
+        $group = $menu->addItem('Admin', '#');
+        $self = new class ('Self', '/self') extends Item implements SelfRendererInterface {
+            public function render(): string
+            {
+                return '<li class="self-item">self</li>';
+            }
+        };
+        // The self-rendering child has only hidden descendants, but it still renders itself.
+        $self->getSubMenu()->addItem('Hidden', '/hidden')->setVisibility(false);
+        $group->add($self);
+
+        $result = (new StringTemplateRenderer())->render($menu, ['hideEmptyBranches' => true]);
+
+        $this->assertStringContainsString('self-item', $result);
         $this->assertStringContainsString('Admin', $result);
     }
 }

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -102,4 +102,28 @@ class StringTemplateRendererTest extends TestCase
 
         $this->assertStringContainsString('aria-current="page"', $result);
     }
+
+    public function testHideEmptyBranchesSkipsBranchWithoutVisibleChildren(): void
+    {
+        $menu = Menu::create();
+        $group = $menu->addItem('Admin', '#');
+        $group->getSubMenu()->addItem('Users', '/admin/users')->setVisibility(false);
+        $menu->addItem('Home', '/');
+
+        $result = (new StringTemplateRenderer())->render($menu, ['hideEmptyBranches' => true]);
+
+        $this->assertStringNotContainsString('Admin', $result);
+        $this->assertStringContainsString('Home', $result);
+    }
+
+    public function testEmptyBranchesRenderByDefault(): void
+    {
+        $menu = Menu::create();
+        $group = $menu->addItem('Admin', '#');
+        $group->getSubMenu()->addItem('Users', '/admin/users')->setVisibility(false);
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertStringContainsString('Admin', $result);
+    }
 }

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -9,6 +9,7 @@ use Cake\Http\ServerRequest;
 use Cake\Routing\Route\Route;
 use Cake\TestSuite\TestCase;
 use Cake\View\View;
+use InvalidArgumentException;
 use Menu\Item\Item;
 use Menu\Item\ItemInterface;
 use Menu\Item\SelfRendererInterface;
@@ -336,5 +337,16 @@ class MenuHelperTest extends TestCase
         $this->assertStringContainsString('Articles', $html);
         // ...and the additional resolver hides the flagged item.
         $this->assertStringNotContainsString('Secret', $html);
+    }
+
+    public function testAdditionalResolversRejectInvalidEntries(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest());
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('additionalResolvers');
+        $menuHelper->render($menu, ['additionalResolvers' => ['not-a-resolver']]);
     }
 }

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -314,4 +314,27 @@ class MenuHelperTest extends TestCase
         $this->assertStringNotContainsString('Admin', $html);
         $this->assertNull($menuHelper->getCurrentItem('main', ['resolveDepth' => 1]));
     }
+
+    public function testAdditionalResolversAugmentDefaults(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest(['url' => '/articles']));
+
+        $menu = Menu::create();
+        $menu->addItem('Articles', '/articles');
+        $menu->addItem('Secret', '/secret', ['data' => ['hide' => true]]);
+
+        $html = $menuHelper->render($menu, [
+            'additionalResolvers' => [
+                new AuthorizationResolver(
+                    static fn (ItemInterface $item): ?bool => $item->getData('hide') ? false : null,
+                ),
+            ],
+        ]);
+
+        // Default URL resolver still marks the matching item active...
+        $this->assertStringContainsString('aria-current="page"', $html);
+        $this->assertStringContainsString('Articles', $html);
+        // ...and the additional resolver hides the flagged item.
+        $this->assertStringNotContainsString('Secret', $html);
+    }
 }


### PR DESCRIPTION
## Summary

Two small ergonomics options that make role-based / access-filtered menus practical, plus docs. Both are covered by tests.

### `additionalResolvers` helper option
Passing a `resolver` to `render()` **replaces** the built-in URL resolvers, so you lose automatic active-state matching. `additionalResolvers` instead **appends** your resolvers to the defaults — so you can add a visibility/permission resolver (e.g. TinyAuth `hasAccess()`) while keeping active-state highlighting:

```php
echo $this->Menu->render('main', [
    'additionalResolvers' => [
        new AuthorizationResolver(fn (ItemInterface $i): ?bool => $i->getData('adminOnly') ? $isAdmin : null),
    ],
]);
```

### `hideEmptyBranches` renderer option
When a resolver hides all of a branch's children (access filtering), the parent would otherwise render as an empty dropdown. `hideEmptyBranches => true` skips any branch with no visible, renderable descendants (evaluated recursively). It considers child *visibility*, not the `depth` cutoff, so a branch with visible children is still kept when its submenu is truncated by `depth`.

Both default to off, so existing output is unchanged.
