### PR TITLE
Add a collapsible Bootstrap 5 sidebar renderer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -384,7 +384,15 @@ it accepts:
 | `linkClass` | `nav-link` | Class on leaf links. |
 | `toggleClass` | `nav-link d-flex justify-content-between align-items-center` | Class on toggle-only branch links. |
 | `toggleButtonClass` | `btn btn-link nav-link border-0 p-0 ms-2` | Class on the separate toggle button used for navigable branches. |
+| `collapseClass` | `collapse` | Class on the branch wrapper element. |
+| `expandedClass` | `show` | Class added to the wrapper when the branch is open. |
+| `toggleAttribute` | `data-bs-toggle` | Toggle attribute on the branch control (value `toggleValue`). Set to `''` to omit (e.g. when wiring your own JS). |
+| `toggleValue` | `collapse` | Value for `toggleAttribute`. |
+| `targetAttribute` | `data-bs-target` | Attribute pointing the navigable-branch toggle button at its wrapper id. |
 | `caret` | `true` | Append a small open/closed indicator (`<span class="menu-caret">`) to branch toggles; set `false` to omit. |
+| `caretOpen` / `caretClosed` | `▾` / `▸` | Glyphs for the open/closed caret. |
+
+The framework-specific keys default to Bootstrap 5; override them (e.g. `toggleAttribute => 'data-toggle'`, `expandedClass => 'is-open'`) to target Bootstrap 4 or another setup without subclassing.
 
 You can override templates per render call:
 
@@ -405,6 +413,11 @@ constructor config when instantiating a renderer directly.
 `Bootstrap5Renderer` overrides some of these defaults: `ancestorClass` → `active`,
 `branchClass` / `submenuClass` → `dropdown`, `nestedMenuClass` → `dropdown-menu`, and
 `addAriaExpanded` → `false` (it emits `aria-expanded` on the toggle link instead).
+
+`Bootstrap5Renderer` also exposes its link-level Bootstrap bits as config (defaults shown), so
+BS4/other setups work without subclassing: `linkClass` (`nav-link`, top-level links),
+`childLinkClass` (`dropdown-item`, nested links), `toggleClass` (`dropdown-toggle`, branch links),
+`toggleAttribute` (`data-bs-toggle`) and `toggleValue` (`dropdown`).
 
 | Option | Default | Description |
 | --- | --- | --- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -390,7 +390,7 @@ it accepts:
 | `toggleValue` | `collapse` | Value for `toggleAttribute`. |
 | `targetAttribute` | `data-bs-target` | Attribute pointing the navigable-branch toggle button at its wrapper id. |
 | `caret` | `true` | Append a small open/closed indicator (`<span class="menu-caret">`) to branch toggles; set `false` to omit. |
-| `caretOpen` / `caretClosed` | `▾` / `▸` | Glyphs for the open/closed caret. |
+| `caretOpen` / `caretClosed` | `▾` / `▸` | Open/closed caret markup (trusted; pass an icon element like a FontAwesome `<i>` if you prefer). |
 
 The framework-specific keys default to Bootstrap 5; override them (e.g. `toggleAttribute => 'data-toggle'`, `expandedClass => 'is-open'`) to target Bootstrap 4 or another setup without subclassing.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -354,6 +354,38 @@ echo $this->Menu->render($menu, [
 ]);
 ```
 
+Collapsible Bootstrap 5 sidebar — a vertical `nav` whose branches are Bootstrap `collapse` regions:
+
+```php
+echo $this->Menu->render('sidebar', [
+    'renderer' => \Menu\Renderer\Bootstrap5SidebarRenderer::class,
+]);
+```
+
+The branch containing the active item is expanded (`collapse show`, `aria-expanded="true"`), all
+other branches start collapsed, and the active leaf gets the active class plus `aria-current="page"`.
+Each branch is wired to its `collapse` element through a unique id, so it works with the standard
+Bootstrap bundle and needs no custom JavaScript. Item and submenu attributes from the menu
+definition are preserved on the `<li>` and nested `<ul>`.
+
+A branch that only groups children (placeholder link `#`/none) renders a single toggle. A branch
+that *also* has a real URL stays navigable: it renders the link plus a separate collapse toggle
+button (`data-bs-target`), so the destination is reachable and its link attributes are kept.
+
+Besides the shared `activeClass`, `currentAsLink`, `addAriaCurrent` and `hideEmptyBranches` options,
+it accepts:
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `idPrefix` | `menu-collapse-` | Prefix for the generated collapse ids. Use a distinct value per sidebar on a page to avoid id collisions. |
+| `navClass` | `nav flex-column` | Class on the root `<ul>`. |
+| `nestedNavClass` | `nav flex-column ms-3` | Class on the nested `<ul>` inside each collapse. |
+| `itemClass` | `nav-item` | Class added to each `<li>` (on top of the item's own attributes). |
+| `linkClass` | `nav-link` | Class on leaf links. |
+| `toggleClass` | `nav-link d-flex justify-content-between align-items-center` | Class on toggle-only branch links. |
+| `toggleButtonClass` | `btn btn-link nav-link border-0 p-0 ms-2` | Class on the separate toggle button used for navigable branches. |
+| `caret` | `true` | Append a small open/closed indicator (`<span class="menu-caret">`) to branch toggles; set `false` to omit. |
+
 You can override templates per render call:
 
 ```php

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -22,6 +22,12 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         'firstClass' => null,
         'lastClass' => null,
         'currentAsLink' => true,
+        // Framework-specific bits, defaulting to Bootstrap 5; override for BS4/other.
+        'linkClass' => 'nav-link',
+        'childLinkClass' => 'dropdown-item',
+        'toggleClass' => 'dropdown-toggle',
+        'toggleAttribute' => 'data-bs-toggle',
+        'toggleValue' => 'dropdown',
         'templates' => [
             'menuWrapper' => '<ul{{attributes}}>{{items}}</ul>',
             'item' => '<li{{attributes}}>{{content}}</li>',
@@ -57,11 +63,16 @@ class Bootstrap5Renderer extends StringTemplateRenderer
 
         $attributes = $link->getAttributes();
         $attributes['href'] = $link->getUrl() ?? '#';
-        $baseLinkClass = $item->hasParent() ? 'dropdown-item' : 'nav-link';
+        $baseLinkClass = $item->hasParent()
+            ? $this->getStringOption($options, 'childLinkClass')
+            : $this->getStringOption($options, 'linkClass');
         $attributes = $this->appendClass($attributes, $baseLinkClass);
         if ($item->hasSubMenu()) {
-            $attributes = $this->appendClass($attributes, 'dropdown-toggle');
-            $attributes['data-bs-toggle'] = 'dropdown';
+            $attributes = $this->appendClass($attributes, $this->getStringOption($options, 'toggleClass'));
+            $toggleAttribute = $this->getStringOption($options, 'toggleAttribute');
+            if ($toggleAttribute !== '') {
+                $attributes[$toggleAttribute] = $this->getStringOption($options, 'toggleValue');
+            }
             $attributes['role'] = $attributes['role'] ?? 'button';
             $attributes['aria-expanded'] = $item->isExpanded() || $item->isActive() || $this->hasActiveDescendant($item)
                 ? 'true'

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Renderer;
+
+use Menu\Item\ItemInterface;
+use Menu\Item\SelfRendererInterface;
+use Menu\MenuInterface;
+use function array_filter;
+use function implode;
+use function preg_replace;
+use function sprintf;
+use function trim;
+
+/**
+ * Renders a menu as a collapsible Bootstrap 5 sidebar: a vertical `nav` whose branches are
+ * Bootstrap `collapse` regions toggled by their parent.
+ *
+ * The branch containing the active item is expanded (`collapse show`, `aria-expanded="true"`),
+ * every other branch starts collapsed, and the active leaf gets the active class plus
+ * `aria-current="page"`. Each branch is wired to its `collapse` element through a unique id
+ * (derived from the item id, prefixed with `idPrefix`); render two sidebars on one page with
+ * different `idPrefix` values to avoid id collisions.
+ *
+ * A branch that also has a real URL stays navigable: it renders the link plus a separate
+ * collapse toggle button. A branch with only a placeholder link (`#`/none) renders a single
+ * toggle. Item and submenu attributes from the menu definition are preserved.
+ *
+ * ```php
+ * echo $this->Menu->render('sidebar', ['renderer' => \Menu\Renderer\Bootstrap5SidebarRenderer::class]);
+ * ```
+ */
+class Bootstrap5SidebarRenderer extends StringTemplateRenderer
+{
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $_defaultConfig = [
+        'activeClass' => 'active',
+        'hideEmptyBranches' => false,
+        'currentAsLink' => true,
+        'addAriaCurrent' => true,
+        // Wires each branch toggle to its collapse element; make it unique per sidebar on a page.
+        'idPrefix' => 'menu-collapse-',
+        'navClass' => 'nav flex-column',
+        'nestedNavClass' => 'nav flex-column ms-3',
+        'itemClass' => 'nav-item',
+        'linkClass' => 'nav-link',
+        'toggleClass' => 'nav-link d-flex justify-content-between align-items-center',
+        // Toggle button used when a branch also has a real URL (link + separate toggle).
+        'toggleButtonClass' => 'btn btn-link nav-link border-0 p-0 ms-2',
+        // Append a small open/closed indicator to branch toggles; set false to omit.
+        'caret' => true,
+    ];
+
+    /**
+     * Fallback counter for branches whose item id does not yield a usable slug.
+     *
+     * @var int
+     */
+    protected int $autoId = 0;
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function render(MenuInterface $menu, array $options = []): string
+    {
+        $this->autoId = 0;
+
+        return $this->renderMenu($menu, $options, 1);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderMenu(MenuInterface $menu, array $options, int $level): string
+    {
+        $items = [];
+        foreach ($menu->getItems() as $item) {
+            if (!$item->isVisible()) {
+                continue;
+            }
+            $html = $this->renderMenuItem($item, $options, 0, 0, $level);
+            if ($html !== '') {
+                $items[] = $html;
+            }
+        }
+
+        $class = $level === 1
+            ? $this->getStringOption($options, 'navClass')
+            : $this->getStringOption($options, 'nestedNavClass');
+        $attributes = $this->appendClass($menu->getAttributes(), $class);
+
+        return sprintf('<ul%s>%s</ul>', $this->renderAttributes($attributes), implode('', $items));
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderMenuItem(
+        ItemInterface $item,
+        array $options,
+        int $index,
+        int $count,
+        int $level,
+    ): string {
+        if (!$item->isVisible()) {
+            return '';
+        }
+        if ($item instanceof SelfRendererInterface) {
+            return $item->render();
+        }
+        if ($item->isDivider()) {
+            return $this->li($item, $options, '<hr class="dropdown-divider">');
+        }
+
+        $hasSubMenu = $item->hasSubMenu();
+        if (
+            $hasSubMenu
+            && $this->getBooleanOption($options, 'hideEmptyBranches', false)
+            && !$this->hasRenderableChild($item, $options)
+        ) {
+            return '';
+        }
+        if ($item->isRaw()) {
+            return $this->li($item, $options, (string)$item->getRaw());
+        }
+
+        $label = $item->getBefore() . $this->escapeLabel($item) . $item->getAfter();
+
+        $content = $hasSubMenu
+            ? $this->renderBranch($item, $options, $label, $level)
+            : $this->renderLeaf($item, $options, $label);
+
+        return $this->li($item, $options, $content);
+    }
+
+    /**
+     * Wraps content in an `<li>` that keeps the item's own attributes plus the item class.
+     *
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function li(ItemInterface $item, array $options, string $content): string
+    {
+        $attributes = $this->appendClass($item->getAttributes(), $this->getStringOption($options, 'itemClass'));
+
+        return sprintf('<li%s>%s</li>', $this->renderAttributes($attributes), $content);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderLeaf(ItemInterface $item, array $options, string $label): string
+    {
+        $active = $item->isActive();
+        $classes = [$this->getStringOption($options, 'linkClass')];
+        if ($active) {
+            $classes[] = $this->getStringOption($options, 'activeClass');
+        }
+
+        $link = $item->getLink();
+        $asLabel = $link === null || ($active && !$this->getBooleanOption($options, 'currentAsLink', true));
+        $attributes = $link !== null && !$asLabel ? $link->getAttributes() : [];
+        $attributes['class'] = $classes;
+        if ($active && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
+            $attributes['aria-current'] = 'page';
+        }
+
+        if ($asLabel) {
+            unset($attributes['href']);
+
+            return sprintf('<span%s>%s</span>', $this->renderAttributes($attributes), $label);
+        }
+
+        $attributes['href'] = $link->getUrl() ?? '#';
+
+        return sprintf('<a%s>%s</a>', $this->renderAttributes($attributes), $label);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderBranch(ItemInterface $item, array $options, string $label, int $level): string
+    {
+        $expanded = $item->isExpanded() || $item->isActive() || $this->hasActiveDescendant($item);
+        $id = $this->collapseId($item, $options);
+        $link = $item->getLink();
+        $url = $link?->getUrl();
+        $hasRealUrl = $url !== null && $url !== '#';
+
+        $head = $hasRealUrl
+            ? $this->renderNavigableBranch($item, $options, $label, $id, $url, $expanded)
+            : $this->renderToggle($options, $label, $id, $expanded);
+
+        $collapse = sprintf(
+            '<div%s>%s</div>',
+            $this->renderAttributes(['class' => array_filter(['collapse', $expanded ? 'show' : null]), 'id' => $id]),
+            $this->renderMenu($item->getSubMenu(), $options, $level + 1),
+        );
+
+        return $head . $collapse;
+    }
+
+    /**
+     * A branch that only groups children: the label itself is the collapse toggle.
+     *
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderToggle(array $options, string $label, string $id, bool $expanded): string
+    {
+        $classes = [$this->getStringOption($options, 'toggleClass')];
+        if ($expanded) {
+            $classes[] = $this->getStringOption($options, 'activeClass');
+        }
+
+        return sprintf(
+            '<a%s>%s%s</a>',
+            $this->renderAttributes([
+                'class' => $classes,
+                'data-bs-toggle' => 'collapse',
+                'role' => 'button',
+                'href' => '#' . $id,
+                'aria-controls' => $id,
+                'aria-expanded' => $expanded ? 'true' : 'false',
+            ]),
+            $label,
+            $this->getBooleanOption($options, 'caret', true) ? $this->caret($expanded) : '',
+        );
+    }
+
+    /**
+     * A branch that also navigates: a real link plus a separate collapse toggle button, so the
+     * destination stays reachable and link attributes (target, rel, title, ...) are preserved.
+     *
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderNavigableBranch(
+        ItemInterface $item,
+        array $options,
+        string $label,
+        string $id,
+        string $url,
+        bool $expanded,
+    ): string {
+        /** @var \Menu\Link\LinkInterface $link */
+        $link = $item->getLink();
+        $linkClasses = [$this->getStringOption($options, 'linkClass')];
+        if ($item->isActive()) {
+            $linkClasses[] = $this->getStringOption($options, 'activeClass');
+        }
+        $linkAttributes = $link->getAttributes();
+        $linkAttributes['class'] = $linkClasses;
+        $linkAttributes['href'] = $url;
+        if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
+            $linkAttributes['aria-current'] = 'page';
+        }
+
+        $anchor = sprintf('<a%s>%s</a>', $this->renderAttributes($linkAttributes), $label);
+        $button = sprintf(
+            '<button%s>%s</button>',
+            $this->renderAttributes([
+                'class' => array_filter([$this->getStringOption($options, 'toggleButtonClass'), $expanded ? $this->getStringOption($options, 'activeClass') : null]),
+                'type' => 'button',
+                'data-bs-toggle' => 'collapse',
+                'data-bs-target' => '#' . $id,
+                'aria-controls' => $id,
+                'aria-expanded' => $expanded ? 'true' : 'false',
+                'aria-label' => 'Toggle section',
+            ]),
+            $this->caret($expanded),
+        );
+
+        return sprintf('<div class="d-flex justify-content-between align-items-center">%s%s</div>', $anchor, $button);
+    }
+
+    protected function caret(bool $expanded): string
+    {
+        return sprintf('<span class="menu-caret ms-2" aria-hidden="true">%s</span>', $expanded ? '&#9662;' : '&#9656;');
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function collapseId(ItemInterface $item, array $options): string
+    {
+        $slug = preg_replace('/[^A-Za-z0-9_-]+/', '-', $item->getId());
+        $slug = trim((string)$slug, '-');
+
+        return $this->getStringOption($options, 'idPrefix') . ($slug !== '' ? $slug : (string)(++$this->autoId));
+    }
+}

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -50,8 +50,16 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
         'toggleClass' => 'nav-link d-flex justify-content-between align-items-center',
         // Toggle button used when a branch also has a real URL (link + separate toggle).
         'toggleButtonClass' => 'btn btn-link nav-link border-0 p-0 ms-2',
+        // Framework-specific bits, defaulting to Bootstrap 5; override for BS4/other.
+        'collapseClass' => 'collapse',
+        'expandedClass' => 'show',
+        'toggleAttribute' => 'data-bs-toggle',
+        'toggleValue' => 'collapse',
+        'targetAttribute' => 'data-bs-target',
         // Append a small open/closed indicator to branch toggles; set false to omit.
         'caret' => true,
+        'caretOpen' => '&#9662;',
+        'caretClosed' => '&#9656;',
     ];
 
     /**
@@ -195,7 +203,13 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
 
         $collapse = sprintf(
             '<div%s>%s</div>',
-            $this->renderAttributes(['class' => array_filter(['collapse', $expanded ? 'show' : null]), 'id' => $id]),
+            $this->renderAttributes([
+                'class' => array_filter([
+                    $this->getStringOption($options, 'collapseClass'),
+                    $expanded ? $this->getStringOption($options, 'expandedClass') : null,
+                ]),
+                'id' => $id,
+            ]),
             $this->renderMenu($item->getSubMenu(), $options, $level + 1),
         );
 
@@ -214,18 +228,23 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
             $classes[] = $this->getStringOption($options, 'activeClass');
         }
 
+        $attributes = ['class' => $classes];
+        $toggleAttribute = $this->getStringOption($options, 'toggleAttribute');
+        if ($toggleAttribute !== '') {
+            $attributes[$toggleAttribute] = $this->getStringOption($options, 'toggleValue');
+        }
+        $attributes += [
+            'role' => 'button',
+            'href' => '#' . $id,
+            'aria-controls' => $id,
+            'aria-expanded' => $expanded ? 'true' : 'false',
+        ];
+
         return sprintf(
             '<a%s>%s%s</a>',
-            $this->renderAttributes([
-                'class' => $classes,
-                'data-bs-toggle' => 'collapse',
-                'role' => 'button',
-                'href' => '#' . $id,
-                'aria-controls' => $id,
-                'aria-expanded' => $expanded ? 'true' : 'false',
-            ]),
+            $this->renderAttributes($attributes),
             $label,
-            $this->getBooleanOption($options, 'caret', true) ? $this->caret($expanded) : '',
+            $this->getBooleanOption($options, 'caret', true) ? $this->caret($options, $expanded) : '',
         );
     }
 
@@ -256,26 +275,40 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
         }
 
         $anchor = sprintf('<a%s>%s</a>', $this->renderAttributes($linkAttributes), $label);
-        $button = sprintf(
-            '<button%s>%s</button>',
-            $this->renderAttributes([
-                'class' => array_filter([$this->getStringOption($options, 'toggleButtonClass'), $expanded ? $this->getStringOption($options, 'activeClass') : null]),
-                'type' => 'button',
-                'data-bs-toggle' => 'collapse',
-                'data-bs-target' => '#' . $id,
-                'aria-controls' => $id,
-                'aria-expanded' => $expanded ? 'true' : 'false',
-                'aria-label' => 'Toggle section',
-            ]),
-            $this->caret($expanded),
-        );
+
+        $buttonAttributes = [
+            'class' => array_filter([$this->getStringOption($options, 'toggleButtonClass'), $expanded ? $this->getStringOption($options, 'activeClass') : null]),
+            'type' => 'button',
+        ];
+        $toggleAttribute = $this->getStringOption($options, 'toggleAttribute');
+        if ($toggleAttribute !== '') {
+            $buttonAttributes[$toggleAttribute] = $this->getStringOption($options, 'toggleValue');
+        }
+        $targetAttribute = $this->getStringOption($options, 'targetAttribute');
+        if ($targetAttribute !== '') {
+            $buttonAttributes[$targetAttribute] = '#' . $id;
+        }
+        $buttonAttributes += [
+            'aria-controls' => $id,
+            'aria-expanded' => $expanded ? 'true' : 'false',
+            'aria-label' => 'Toggle section',
+        ];
+
+        $button = sprintf('<button%s>%s</button>', $this->renderAttributes($buttonAttributes), $this->caret($options, $expanded));
 
         return sprintf('<div class="d-flex justify-content-between align-items-center">%s%s</div>', $anchor, $button);
     }
 
-    protected function caret(bool $expanded): string
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function caret(array $options, bool $expanded): string
     {
-        return sprintf('<span class="menu-caret ms-2" aria-hidden="true">%s</span>', $expanded ? '&#9662;' : '&#9656;');
+        $glyph = $expanded
+            ? $this->getStringOption($options, 'caretOpen')
+            : $this->getStringOption($options, 'caretClosed');
+
+        return sprintf('<span class="menu-caret ms-2" aria-hidden="true">%s</span>', $glyph);
     }
 
     /**

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -154,15 +154,15 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
     protected function renderLeaf(ItemInterface $item, array $options, string $label): string
     {
         $active = $item->isActive();
-        $classes = [$this->getStringOption($options, 'linkClass')];
-        if ($active) {
-            $classes[] = $this->getStringOption($options, 'activeClass');
-        }
-
         $link = $item->getLink();
         $asLabel = $link === null || ($active && !$this->getBooleanOption($options, 'currentAsLink', true));
-        $attributes = $link !== null && !$asLabel ? $link->getAttributes() : [];
-        $attributes['class'] = $classes;
+
+        // Keep the link's own attributes (title, data-*, custom classes) and merge our classes in.
+        $attributes = $link?->getAttributes() ?? [];
+        $attributes = $this->appendClass($attributes, $this->getStringOption($options, 'linkClass'));
+        if ($active) {
+            $attributes = $this->appendClass($attributes, $this->getStringOption($options, 'activeClass'));
+        }
         if ($active && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
             $attributes['aria-current'] = 'page';
         }
@@ -245,12 +245,11 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
     ): string {
         /** @var \Menu\Link\LinkInterface $link */
         $link = $item->getLink();
-        $linkClasses = [$this->getStringOption($options, 'linkClass')];
+        // Keep the link's own attributes and merge our classes in (do not overwrite).
+        $linkAttributes = $this->appendClass($link->getAttributes(), $this->getStringOption($options, 'linkClass'));
         if ($item->isActive()) {
-            $linkClasses[] = $this->getStringOption($options, 'activeClass');
+            $linkAttributes = $this->appendClass($linkAttributes, $this->getStringOption($options, 'activeClass'));
         }
-        $linkAttributes = $link->getAttributes();
-        $linkAttributes['class'] = $linkClasses;
         $linkAttributes['href'] = $url;
         if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
             $linkAttributes['aria-current'] = 'page';

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -57,9 +57,10 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
         'toggleValue' => 'collapse',
         'targetAttribute' => 'data-bs-target',
         // Append a small open/closed indicator to branch toggles; set false to omit.
+        // caretOpen/caretClosed are rendered as trusted markup (use an icon tag if you like).
         'caret' => true,
-        'caretOpen' => '&#9662;',
-        'caretClosed' => '&#9656;',
+        'caretOpen' => '▾',
+        'caretClosed' => '▸',
     ];
 
     /**
@@ -70,20 +71,22 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
     protected int $autoId = 0;
 
     /**
-     * @phpstan-param array<string, mixed> $options
+     * Collapse ids already used in the current render, to guarantee uniqueness.
+     *
+     * @var array<string, true>
      */
-    public function render(MenuInterface $menu, array $options = []): string
-    {
-        $this->autoId = 0;
-
-        return $this->renderMenu($menu, $options, 1);
-    }
+    protected array $usedIds = [];
 
     /**
      * @phpstan-param array<string, mixed> $options
      */
     protected function renderMenu(MenuInterface $menu, array $options, int $level): string
     {
+        if ($level === 1) {
+            $this->autoId = 0;
+            $this->usedIds = [];
+        }
+
         $items = [];
         foreach ($menu->getItems() as $item) {
             if (!$item->isVisible()) {
@@ -291,7 +294,7 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
         $buttonAttributes += [
             'aria-controls' => $id,
             'aria-expanded' => $expanded ? 'true' : 'false',
-            'aria-label' => 'Toggle section',
+            'aria-label' => trim('Toggle ' . (string)$item->getLabel()),
         ];
 
         $button = sprintf('<button%s>%s</button>', $this->renderAttributes($buttonAttributes), $this->caret($options, $expanded));
@@ -300,6 +303,9 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
     }
 
     /**
+     * The caret glyph is renderer config (not menu data) and is emitted as trusted markup,
+     * so an icon element (e.g. a FontAwesome `<i>`) can be used.
+     *
      * @phpstan-param array<string, mixed> $options
      */
     protected function caret(array $options, bool $expanded): string
@@ -318,7 +324,17 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
     {
         $slug = preg_replace('/[^A-Za-z0-9_-]+/', '-', $item->getId());
         $slug = trim((string)$slug, '-');
+        $base = $this->getStringOption($options, 'idPrefix') . ($slug !== '' ? $slug : (string)(++$this->autoId));
 
-        return $this->getStringOption($options, 'idPrefix') . ($slug !== '' ? $slug : (string)(++$this->autoId));
+        // Distinct item ids can slugify to the same value; keep collapse ids unique per render.
+        $id = $base;
+        $suffix = 1;
+        while (isset($this->usedIds[$id])) {
+            $suffix++;
+            $id = $base . '-' . $suffix;
+        }
+        $this->usedIds[$id] = true;
+
+        return $id;
     }
 }

--- a/tests/TestCase/Renderer/Bootstrap5RendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5RendererTest.php
@@ -35,6 +35,30 @@ class Bootstrap5RendererTest extends TestCase
         $this->assertStringNotContainsString('Array', $secondResult);
     }
 
+    public function testFrameworkClassesAndToggleAttributeAreConfigurable(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+        $parent = $menu->addItem('Account', '#');
+        $parent->getSubMenu()->addItem('Profile', '/profile');
+
+        $result = (new Bootstrap5Renderer())->render($menu, [
+            'linkClass' => 'menu-link',
+            'childLinkClass' => 'menu-sublink',
+            'toggleClass' => 'menu-toggle',
+            'toggleAttribute' => 'data-toggle',
+        ]);
+
+        $this->assertStringContainsString('class="menu-link"', $result);
+        $this->assertStringContainsString('menu-toggle', $result);
+        $this->assertStringContainsString('menu-sublink', $result);
+        $this->assertStringContainsString('data-toggle="dropdown"', $result);
+        // Bootstrap defaults are fully replaced, not appended.
+        $this->assertStringNotContainsString('data-bs-toggle', $result);
+        $this->assertStringNotContainsString('nav-link', $result);
+        $this->assertStringNotContainsString('dropdown-item', $result);
+    }
+
     public function testRendersArrayLinkClassWithoutCorruption(): void
     {
         $menu = Menu::create();

--- a/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Menu\Test\TestCase\Renderer;
 
 use Cake\TestSuite\TestCase;
+use Menu\Link\Link;
 use Menu\Menu;
 use Menu\Renderer\Bootstrap5SidebarRenderer;
 
@@ -97,6 +98,24 @@ class Bootstrap5SidebarRendererTest extends TestCase
         $this->assertStringContainsString('<button', $result);
         $this->assertStringContainsString('data-bs-target="#menu-collapse-products"', $result);
         $this->assertStringContainsString('id="menu-collapse-products"', $result);
+    }
+
+    public function testPreservesLinkAttributesAndMergesClasses(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', Link::create('/home', ['class' => 'text-danger', 'title' => 'Go home']));
+        $menu->addItem('Current', Link::create('/current', ['title' => 'Here']), ['active' => true]);
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu, ['currentAsLink' => false]);
+
+        // The link keeps its own class (merged with nav-link) and its title.
+        $this->assertStringContainsString('text-danger', $result);
+        $this->assertStringContainsString('nav-link', $result);
+        $this->assertStringContainsString('title="Go home"', $result);
+        // The active item rendered as a label keeps its attributes (title) and has no href.
+        $this->assertStringContainsString('title="Here"', $result);
+        $this->assertMatchesRegularExpression('/<span[^>]*class="nav-link active"[^>]*>Current<\/span>/', $result);
+        $this->assertStringNotContainsString('Array', $result);
     }
 
     public function testHideEmptyBranchesDropsChildlessBranch(): void

--- a/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
@@ -98,6 +98,24 @@ class Bootstrap5SidebarRendererTest extends TestCase
         $this->assertStringContainsString('<button', $result);
         $this->assertStringContainsString('data-bs-target="#menu-collapse-products"', $result);
         $this->assertStringContainsString('id="menu-collapse-products"', $result);
+        // The toggle button names its section for screen readers.
+        $this->assertStringContainsString('aria-label="Toggle Products"', $result);
+    }
+
+    public function testGeneratesUniqueCollapseIdsForCollidingSlugs(): void
+    {
+        $menu = Menu::create();
+        $a = $menu->addItem('A', '#', ['id' => 'a b']);
+        $a->getSubMenu()->addItem('A1', '/a1');
+        $b = $menu->addItem('B', '#', ['id' => 'a-b']);
+        $b->getSubMenu()->addItem('B1', '/b1');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        // Both item ids slugify to "a-b"; the second collapse id must be disambiguated.
+        $this->assertStringContainsString('id="menu-collapse-a-b"', $result);
+        $this->assertStringContainsString('id="menu-collapse-a-b-2"', $result);
+        $this->assertStringContainsString('href="#menu-collapse-a-b-2"', $result);
     }
 
     public function testPreservesLinkAttributesAndMergesClasses(): void

--- a/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Renderer;
+
+use Cake\TestSuite\TestCase;
+use Menu\Menu;
+use Menu\Renderer\Bootstrap5SidebarRenderer;
+
+class Bootstrap5SidebarRendererTest extends TestCase
+{
+    public function testRendersCollapsibleSidebarWithActiveBranchOpen(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Dashboard', '/dashboard');
+        $features = $menu->addItem('Features', '#', ['id' => 'features']);
+        $features->getSubMenu()->addItem('Resolvers', '/resolvers');
+        $features->getSubMenu()->addItem('Renderers', '/renderers', ['active' => true]);
+        $more = $menu->addItem('More', '#', ['id' => 'more']);
+        $more->getSubMenu()->addItem('Docs', '/docs');
+
+        $renderer = new Bootstrap5SidebarRenderer();
+        $result = $renderer->render($menu);
+        $secondResult = $renderer->render($menu);
+
+        // Vertical nav and items.
+        $this->assertStringContainsString('<ul class="nav flex-column">', $result);
+        $this->assertStringContainsString('<li class="nav-item">', $result);
+        $this->assertStringContainsString('href="/dashboard"', $result);
+        $this->assertStringContainsString('<ul class="nav flex-column ms-3">', $result);
+
+        // The branch holding the active item is wired and expanded.
+        $this->assertStringContainsString('data-bs-toggle="collapse"', $result);
+        $this->assertStringContainsString('href="#menu-collapse-features"', $result);
+        $this->assertStringContainsString('aria-controls="menu-collapse-features"', $result);
+        $this->assertStringContainsString('aria-expanded="true"', $result);
+        $this->assertStringContainsString('<div class="collapse show" id="menu-collapse-features">', $result);
+
+        // The active leaf carries the active class and aria-current.
+        $this->assertStringContainsString('class="nav-link active"', $result);
+        $this->assertStringContainsString('href="/renderers"', $result);
+        $this->assertStringContainsString('aria-current="page"', $result);
+
+        // The branch without an active descendant stays collapsed.
+        $this->assertStringContainsString('aria-expanded="false"', $result);
+        $this->assertStringContainsString('<div class="collapse" id="menu-collapse-more">', $result);
+
+        // Deterministic output, no array leakage into attributes.
+        $this->assertSame($result, $secondResult);
+        $this->assertStringNotContainsString('Array', $result);
+    }
+
+    public function testIdPrefixOptionAvoidsCollisions(): void
+    {
+        $menu = Menu::create();
+        $branch = $menu->addItem('Account', '#', ['id' => 'account']);
+        $branch->getSubMenu()->addItem('Profile', '/profile');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu, ['idPrefix' => 'aside-']);
+
+        $this->assertStringContainsString('href="#aside-account"', $result);
+        $this->assertStringContainsString('id="aside-account"', $result);
+        $this->assertStringNotContainsString('menu-collapse-', $result);
+    }
+
+    public function testPreservesItemAndSubmenuAttributes(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Dashboard', '/dashboard', ['attributes' => ['class' => 'custom', 'data-x' => '1']]);
+        $features = $menu->addItem('Features', '#', [
+            'id' => 'features',
+            'submenuAttributes' => ['class' => 'sub-extra', 'data-sub' => 'y'],
+        ]);
+        $features->getSubMenu()->addItem('Resolvers', '/resolvers');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        // Item attributes survive on the <li> (alongside the item class).
+        $this->assertMatchesRegularExpression('/<li class="custom nav-item" data-x="1">/', $result);
+        // Submenu attributes survive on the nested <ul>.
+        $this->assertStringContainsString('sub-extra', $result);
+        $this->assertStringContainsString('data-sub="y"', $result);
+    }
+
+    public function testBranchWithRealUrlStaysNavigable(): void
+    {
+        $menu = Menu::create();
+        $products = $menu->addItem('Products', '/products', ['id' => 'products']);
+        $products->getSubMenu()->addItem('Books', '/books');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        // The branch keeps its real destination...
+        $this->assertStringContainsString('href="/products"', $result);
+        // ...and a separate collapse toggle drives the section (data-bs-target, not href="#...").
+        $this->assertStringContainsString('<button', $result);
+        $this->assertStringContainsString('data-bs-target="#menu-collapse-products"', $result);
+        $this->assertStringContainsString('id="menu-collapse-products"', $result);
+    }
+
+    public function testHideEmptyBranchesDropsChildlessBranch(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+        $empty = $menu->addItem('Empty', '#', ['id' => 'empty']);
+        $empty->getSubMenu()->addItem('Hidden', '/hidden', ['visible' => false]);
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu, ['hideEmptyBranches' => true]);
+
+        $this->assertStringContainsString('href="/"', $result);
+        $this->assertStringNotContainsString('id="menu-collapse-empty"', $result);
+    }
+}

--- a/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
@@ -118,6 +118,28 @@ class Bootstrap5SidebarRendererTest extends TestCase
         $this->assertStringNotContainsString('Array', $result);
     }
 
+    public function testFrameworkHooksAreConfigurable(): void
+    {
+        $menu = Menu::create();
+        $branch = $menu->addItem('Group', '#', ['id' => 'group']);
+        $branch->getSubMenu()->addItem('Child', '/child', ['active' => true]);
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu, [
+            'collapseClass' => 'accordion-collapse',
+            'expandedClass' => 'is-open',
+            'toggleAttribute' => 'data-toggle',
+            'caretOpen' => 'v',
+            'caretClosed' => '>',
+        ]);
+
+        // Active branch open, using the overridden collapse/expanded classes.
+        $this->assertStringContainsString('class="accordion-collapse is-open"', $result);
+        $this->assertStringContainsString('data-toggle="collapse"', $result);
+        $this->assertStringContainsString('>v</span>', $result);
+        // Bootstrap defaults replaced, not appended.
+        $this->assertStringNotContainsString('data-bs-toggle', $result);
+    }
+
     public function testHideEmptyBranchesDropsChildlessBranch(): void
     {
         $menu = Menu::create();


### PR DESCRIPTION
## Summary

Adds `Bootstrap5SidebarRenderer` — renders a menu as a **collapsible Bootstrap 5 sidebar** (a vertical `nav` whose branches are Bootstrap `collapse` regions).

```php
echo $this->Menu->render('sidebar', [
    'renderer' => \Menu\Renderer\Bootstrap5SidebarRenderer::class,
]);
```

## Behavior

- The branch containing the **active item** is expanded (`collapse show`, `aria-expanded="true"`); every other branch starts collapsed.
- The active leaf gets the active class + `aria-current="page"`.
- Each branch is wired to its `collapse` element via a unique id (derived from the item id, `idPrefix`-prefixed) — works with the standard Bootstrap bundle, **no custom JS**.
- **Item and submenu attributes** from the menu definition are preserved (on the `<li>` and nested `<ul>`).
- A branch that only groups children renders a single toggle; a branch that **also has a real URL stays navigable** (renders the link + a separate collapse toggle button via `data-bs-target`, keeping the destination reachable and its link attributes intact).

## Options

`idPrefix`, `navClass`, `nestedNavClass`, `itemClass`, `linkClass`, `toggleClass`, `toggleButtonClass`, `caret` — plus the shared `activeClass` / `currentAsLink` / `addAriaCurrent` / `hideEmptyBranches`. Documented in `docs/README.md`.

Extends `StringTemplateRenderer`, reusing its active-state / attribute / escaping helpers. Covered by tests (active branch open, idPrefix, hideEmptyBranches, item/submenu attribute preservation, navigable branch).

> Motivated by the sandbox Menu demo, which had to hand-roll exactly this sidebar.
