### PR TITLE
Add singleActive arbitration and first-class icons/badges

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,9 @@ $this->Menu->register('main', static function ($menu): void {
 - `submenuAttributes`: nested `<ul>` attributes
 - `before`: raw markup before the label/link
 - `after`: raw markup after the label/link
+- `icon`: icon class rendered before the label (e.g. `fa fa-inbox`)
+- `badge`: badge text/count rendered after the label
+- `badgeType`: extra CSS class for the badge (e.g. `bg-danger`)
 - `data`: arbitrary metadata consumed by your app or resolvers
 - `visible`: initial visibility
 - `active`: initial active state
@@ -317,6 +320,19 @@ echo $this->Menu->render('main', [
 
 This looks at child *visibility*, not the `depth` cutoff: a branch with visible children is still a
 valid top-level entry when its submenu is truncated by `depth`, so it is kept.
+
+### Single Active Item
+
+When several items match the current URL (e.g. a parent and a child both pointing at the same
+route), `getActiveItem()` and breadcrumbs follow the first match in document order. Enable
+`singleActive` to keep only the **best** match active — the deepest item in the tree, breaking ties
+by document order — so the active trail is unambiguous:
+
+```php
+echo $this->Menu->render('main', [
+    'singleActive' => true,
+]);
+```
 
 ### Breadcrumb Integration
 
@@ -593,21 +609,24 @@ echo $this->Menu->render('admin');
 
 ### Icons and Badges
 
-`before`, `after`, and `raw` are emitted as trusted markup, so they are handy for icon fonts and
-counters:
+Icons and badges are first-class: `setIcon()` and `setBadge()` (or the `icon`/`badge`/`badgeType`
+options) are escaped for you and rendered around the label.
 
 ```php
-$menu->addItem('Dashboard', ['controller' => 'Dashboard', 'action' => 'index'], [
-    'before' => '<i class="fa fa-gauge"></i> ',
-]);
+$menu->addItem('Dashboard', ['controller' => 'Dashboard', 'action' => 'index'])
+    ->setIcon('fa fa-gauge');
 
-$menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'], [
-    'after' => ' <span class="badge">' . (int)$unread . '</span>',
-]);
+$menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'])
+    ->setBadge($unread, 'bg-danger');
+
+// Same via options:
+$menu->addItem('Profile', '/profile', ['icon' => 'fa fa-user', 'badge' => 'new']);
 ```
 
-Because `before`/`after`/`raw` are emitted verbatim, cast or escape any dynamic value you put in
-them (here `(int)$unread`).
+The markup is overridable per render with the `iconTemplate` / `badgeTemplate` options
+(`{{icon}}`, and `{{class}}`/`{{text}}` placeholders). For anything more custom, `before`, `after`,
+and `raw` are still emitted as trusted markup — cast or escape dynamic values you put there yourself
+(e.g. `(int)$count`).
 
 ### Defining a Menu in Config
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -610,30 +610,16 @@ echo $this->Menu->render('admin');
 
 ### Icons and Badges
 
-Icons and badges are first-class: the `icon`/`badge`/`badgeType` options are escaped for you and
-rendered around the label.
+Icons and badges are first-class: `setIcon()` / `setBadge()` (on `ItemInterface`) or the
+`icon`/`badge`/`badgeType` options are escaped for you and rendered around the label.
 
 ```php
-$menu->addItem('Dashboard', ['controller' => 'Dashboard', 'action' => 'index'], [
-    'icon' => 'fa fa-gauge',
-]);
+$menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'])
+    ->setIcon('fa fa-inbox')
+    ->setBadge($unread, 'bg-danger');
 
-$menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'], [
-    'icon' => 'fa fa-inbox',
-    'badge' => $unread,
-    'badgeType' => 'bg-danger',
-]);
-```
-
-The fluent `setIcon()` / `setBadge()` setters are also available on a concrete `Item`
-(`Menu::addItem()` / `newItem()` are typed to return `ItemInterface`, so prefer the options above for
-the common case):
-
-```php
-use Menu\Item\Item;
-
-$item = (new Item('Profile', '/profile'))->setIcon('fa fa-user')->setBadge('new');
-$menu->add($item);
+// Same via options:
+$menu->addItem('Profile', '/profile', ['icon' => 'fa fa-user', 'badge' => 'new']);
 ```
 
 The markup is overridable per render with the `iconTemplate` / `badgeTemplate` options

--- a/docs/README.md
+++ b/docs/README.md
@@ -325,8 +325,9 @@ valid top-level entry when its submenu is truncated by `depth`, so it is kept.
 
 When several items match the current URL (e.g. a parent and a child both pointing at the same
 route), `getActiveItem()` and breadcrumbs follow the first match in document order. Enable
-`singleActive` to keep only the **best** match active — the deepest item in the tree, breaking ties
-by document order — so the active trail is unambiguous:
+`singleActive` to keep only the **best** match active — the deepest *visible* item that actually
+renders (items hidden, or under hidden ancestors, are skipped), breaking ties by document order — so
+the active trail is unambiguous:
 
 ```php
 echo $this->Menu->render('main', [
@@ -609,18 +610,30 @@ echo $this->Menu->render('admin');
 
 ### Icons and Badges
 
-Icons and badges are first-class: `setIcon()` and `setBadge()` (or the `icon`/`badge`/`badgeType`
-options) are escaped for you and rendered around the label.
+Icons and badges are first-class: the `icon`/`badge`/`badgeType` options are escaped for you and
+rendered around the label.
 
 ```php
-$menu->addItem('Dashboard', ['controller' => 'Dashboard', 'action' => 'index'])
-    ->setIcon('fa fa-gauge');
+$menu->addItem('Dashboard', ['controller' => 'Dashboard', 'action' => 'index'], [
+    'icon' => 'fa fa-gauge',
+]);
 
-$menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'])
-    ->setBadge($unread, 'bg-danger');
+$menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'], [
+    'icon' => 'fa fa-inbox',
+    'badge' => $unread,
+    'badgeType' => 'bg-danger',
+]);
+```
 
-// Same via options:
-$menu->addItem('Profile', '/profile', ['icon' => 'fa fa-user', 'badge' => 'new']);
+The fluent `setIcon()` / `setBadge()` setters are also available on a concrete `Item`
+(`Menu::addItem()` / `newItem()` are typed to return `ItemInterface`, so prefer the options above for
+the common case):
+
+```php
+use Menu\Item\Item;
+
+$item = (new Item('Profile', '/profile'))->setIcon('fa fa-user')->setBadge('new');
+$menu->add($item);
 ```
 
 The markup is overridable per render with the `iconTemplate` / `badgeTemplate` options

--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -41,6 +41,12 @@ class Item implements ItemInterface, StateResetInterface
 
     protected string $after = '';
 
+    protected ?string $icon = null;
+
+    protected ?string $badge = null;
+
+    protected ?string $badgeType = null;
+
     /**
      * @var array<string, mixed>
      */
@@ -304,6 +310,38 @@ class Item implements ItemInterface, StateResetInterface
         return $this->after;
     }
 
+    public function setIcon(?string $icon): static
+    {
+        $this->assertMutable();
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function getIcon(): ?string
+    {
+        return $this->icon;
+    }
+
+    public function setBadge(string|int|null $badge, ?string $type = null): static
+    {
+        $this->assertMutable();
+        $this->badge = $badge === null ? null : (string)$badge;
+        $this->badgeType = $type;
+
+        return $this;
+    }
+
+    public function getBadge(): ?string
+    {
+        return $this->badge;
+    }
+
+    public function getBadgeType(): ?string
+    {
+        return $this->badgeType;
+    }
+
     public function setAttribute(string $name, mixed $value): static
     {
         $this->assertMutable();
@@ -452,6 +490,9 @@ class Item implements ItemInterface, StateResetInterface
             'expanded' => $this->expanded,
             'before' => $this->before,
             'after' => $this->after,
+            'icon' => $this->icon,
+            'badge' => $this->badge,
+            'badgeType' => $this->badgeType,
             'attributes' => $this->attributes,
             'data' => $this->data,
             'matchRoutes' => $this->matchRoutes,

--- a/src/Item/ItemInterface.php
+++ b/src/Item/ItemInterface.php
@@ -74,6 +74,16 @@ interface ItemInterface
 
     public function getAfter(): string;
 
+    public function setIcon(?string $icon): static;
+
+    public function getIcon(): ?string;
+
+    public function setBadge(string|int|null $badge, ?string $type = null): static;
+
+    public function getBadge(): ?string;
+
+    public function getBadgeType(): ?string;
+
     public function setAttribute(string $name, mixed $value): static;
 
     /**

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -76,6 +76,9 @@ class Menu implements MenuInterface
                     'escape' => $itemConfig['escape'] ?? true,
                     'before' => $itemConfig['before'] ?? null,
                     'after' => $itemConfig['after'] ?? null,
+                    'icon' => $itemConfig['icon'] ?? null,
+                    'badge' => $itemConfig['badge'] ?? null,
+                    'badgeType' => $itemConfig['badgeType'] ?? null,
                     'attributes' => $itemConfig['attributes'] ?? [],
                     'data' => $itemConfig['data'] ?? [],
                     'visible' => $itemConfig['visible'] ?? true,
@@ -190,6 +193,12 @@ class Menu implements MenuInterface
         }
         if (isset($options['after'])) {
             $item->setAfter((string)$options['after']);
+        }
+        if (isset($options['icon']) && $item instanceof Item) {
+            $item->setIcon((string)$options['icon']);
+        }
+        if (isset($options['badge']) && $item instanceof Item) {
+            $item->setBadge((string)$options['badge'], isset($options['badgeType']) ? (string)$options['badgeType'] : null);
         }
         if (isset($options['attributes']) && is_array($options['attributes'])) {
             $item->setAttributes($options['attributes']);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -194,10 +194,10 @@ class Menu implements MenuInterface
         if (isset($options['after'])) {
             $item->setAfter((string)$options['after']);
         }
-        if (isset($options['icon']) && $item instanceof Item) {
+        if (isset($options['icon'])) {
             $item->setIcon((string)$options['icon']);
         }
-        if (isset($options['badge']) && $item instanceof Item) {
+        if (isset($options['badge'])) {
             $item->setBadge((string)$options['badge'], isset($options['badgeType']) ? (string)$options['badgeType'] : null);
         }
         if (isset($options['attributes']) && is_array($options['attributes'])) {

--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -46,7 +46,7 @@ class Bootstrap5Renderer extends StringTemplateRenderer
             return (string)$item->getRaw();
         }
 
-        $label = $this->escapeLabel($item);
+        $title = $this->decorateTitle($item, $this->escapeLabel($item), $options);
         $link = $item->getLink();
         if ($link === null || ($item->isActive() && !$this->getBooleanOption($options, 'currentAsLink', true))) {
             $attributes = $link?->getAttributes() ?? [];
@@ -57,7 +57,7 @@ class Bootstrap5Renderer extends StringTemplateRenderer
 
             return $this->templater()->format('label', [
                 'attributes' => $this->renderAttributes($attributes),
-                'title' => $label,
+                'title' => $title,
             ]);
         }
 
@@ -84,7 +84,7 @@ class Bootstrap5Renderer extends StringTemplateRenderer
 
         return $this->templater()->format('link', [
             'attributes' => $this->renderAttributes($attributes),
-            'title' => $label,
+            'title' => $title,
         ]);
     }
 }

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -138,7 +138,9 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
             return $this->li($item, $options, (string)$item->getRaw());
         }
 
-        $label = $item->getBefore() . $this->escapeLabel($item) . $item->getAfter();
+        $label = $item->getBefore()
+            . $this->decorateTitle($item, $this->escapeLabel($item), $options)
+            . $item->getAfter();
 
         $content = $hasSubMenu
             ? $this->renderBranch($item, $options, $label, $level)

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -6,6 +6,7 @@ namespace Menu\Renderer;
 
 use Cake\Core\InstanceConfigTrait;
 use Cake\View\StringTemplateTrait;
+use Menu\Item\Item;
 use Menu\Item\ItemInterface;
 use Menu\Item\SelfRendererInterface;
 use Menu\MenuInterface;
@@ -19,6 +20,7 @@ use function implode;
 use function in_array;
 use function is_array;
 use function sprintf;
+use function str_replace;
 use function trim;
 
 class StringTemplateRenderer implements RendererInterface
@@ -205,7 +207,7 @@ class StringTemplateRenderer implements RendererInterface
             return (string)$item->getRaw();
         }
 
-        $label = $this->escapeLabel($item);
+        $title = $this->decorateTitle($item, $this->escapeLabel($item), $options);
         $link = $item->getLink();
         if ($link === null || ($item->isActive() && !$this->getBooleanOption($options, 'currentAsLink', true))) {
             $attributes = $link?->getAttributes() ?? [];
@@ -216,7 +218,7 @@ class StringTemplateRenderer implements RendererInterface
 
             return $this->templater()->format('label', [
                 'attributes' => $this->renderAttributes($attributes),
-                'title' => $label,
+                'title' => $title,
             ]);
         }
 
@@ -228,7 +230,7 @@ class StringTemplateRenderer implements RendererInterface
 
         return $this->templater()->format('link', [
             'attributes' => $this->renderAttributes($attributes),
-            'title' => $label,
+            'title' => $title,
         ]);
     }
 
@@ -241,6 +243,54 @@ class StringTemplateRenderer implements RendererInterface
         }
 
         return htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
+     * Wraps a (already escaped) label with the item's icon and badge, if any.
+     *
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function decorateTitle(ItemInterface $item, string $label, array $options): string
+    {
+        return $this->renderIcon($item, $options) . $label . $this->renderBadge($item, $options);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderIcon(ItemInterface $item, array $options): string
+    {
+        $icon = $item instanceof Item ? (string)$item->getIcon() : '';
+        if ($icon === '') {
+            return '';
+        }
+
+        $template = $this->getStringOption($options, 'iconTemplate') ?: '<i class="{{icon}}" aria-hidden="true"></i> ';
+
+        return str_replace('{{icon}}', htmlspecialchars($icon, ENT_QUOTES, 'UTF-8'), $template);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function renderBadge(ItemInterface $item, array $options): string
+    {
+        if (!$item instanceof Item) {
+            return '';
+        }
+        $badge = (string)$item->getBadge();
+        if ($badge === '') {
+            return '';
+        }
+
+        $class = trim('badge ' . (string)$item->getBadgeType());
+        $template = $this->getStringOption($options, 'badgeTemplate') ?: ' <span class="{{class}}">{{text}}</span>';
+
+        return str_replace(
+            ['{{class}}', '{{text}}'],
+            [htmlspecialchars($class, ENT_QUOTES, 'UTF-8'), htmlspecialchars($badge, ENT_QUOTES, 'UTF-8')],
+            $template,
+        );
     }
 
     /**

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -246,7 +246,8 @@ class StringTemplateRenderer implements RendererInterface
     }
 
     /**
-     * Wraps a (already escaped) label with the item's icon and badge, if any.
+     * Wraps the rendered label (escaped, unless the item opts out of escaping) with the item's
+     * icon and badge, if any.
      *
      * @phpstan-param array<string, mixed> $options
      */

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -6,7 +6,6 @@ namespace Menu\Renderer;
 
 use Cake\Core\InstanceConfigTrait;
 use Cake\View\StringTemplateTrait;
-use Menu\Item\Item;
 use Menu\Item\ItemInterface;
 use Menu\Item\SelfRendererInterface;
 use Menu\MenuInterface;
@@ -261,7 +260,7 @@ class StringTemplateRenderer implements RendererInterface
      */
     protected function renderIcon(ItemInterface $item, array $options): string
     {
-        $icon = $item instanceof Item ? (string)$item->getIcon() : '';
+        $icon = (string)$item->getIcon();
         if ($icon === '') {
             return '';
         }
@@ -276,9 +275,6 @@ class StringTemplateRenderer implements RendererInterface
      */
     protected function renderBadge(ItemInterface $item, array $options): string
     {
-        if (!$item instanceof Item) {
-            return '';
-        }
         $badge = (string)$item->getBadge();
         if ($badge === '') {
             return '';

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -341,6 +341,74 @@ class MenuHelper extends Helper
 
         $menu->resetState();
         $menu->resolve($resolver);
+
+        if (!empty($options['singleActive'])) {
+            $this->enforceSingleActive($menu);
+        }
+    }
+
+    /**
+     * Keeps only the best (deepest) active item active, deactivating the rest.
+     *
+     * Resolvers can mark several items active for one request; this picks the most specific match
+     * — the deepest in the tree, breaking ties by document order — so `getActiveItem()` and
+     * breadcrumbs follow a single trail.
+     */
+    protected function enforceSingleActive(MenuInterface $menu): void
+    {
+        /** @var list<array{item: \Menu\Item\ItemInterface, depth: int, visible: bool}> $active */
+        $active = [];
+        $this->collectActiveItems($menu, 1, true, $active);
+        if ($active === []) {
+            return;
+        }
+
+        // Best match = the deepest active item that actually renders (visible, with visible
+        // ancestors), breaking ties by document order.
+        $best = null;
+        $bestDepth = -1;
+        foreach ($active as $entry) {
+            if ($entry['visible'] && $entry['depth'] > $bestDepth) {
+                $best = $entry['item'];
+                $bestDepth = $entry['depth'];
+            }
+        }
+
+        // Deactivate every other active item, including hidden ones that getActiveItem() would
+        // otherwise still walk into.
+        foreach ($active as $entry) {
+            if ($entry['item'] === $best) {
+                continue;
+            }
+            $item = $entry['item'];
+            if ($item instanceof StateResetInterface) {
+                $item->setRuntimeActive(false);
+            } else {
+                $item->setActive(false);
+            }
+        }
+    }
+
+    /**
+     * Collects every active item in the tree, recording its depth and whether it (and all its
+     * ancestors) are visible — i.e. whether it would actually render.
+     *
+     * @param \Menu\MenuInterface $menu
+     * @param int $depth
+     * @param bool $ancestorsVisible
+     * @param list<array{item: \Menu\Item\ItemInterface, depth: int, visible: bool}> $active
+     */
+    protected function collectActiveItems(MenuInterface $menu, int $depth, bool $ancestorsVisible, array &$active): void
+    {
+        foreach ($menu->getItems() as $item) {
+            $visible = $ancestorsVisible && $item->isVisible();
+            if ($item->isActive()) {
+                $active[] = ['item' => $item, 'depth' => $depth, 'visible' => $visible];
+            }
+            if ($item->hasSubMenu()) {
+                $this->collectActiveItems($item->getSubMenu(), $depth + 1, $visible, $active);
+            }
+        }
     }
 
     protected function invokeRegisterCallback(callable $callback, MenuInterface $menu): void

--- a/tests/TestCase/Item/ItemTest.php
+++ b/tests/TestCase/Item/ItemTest.php
@@ -79,4 +79,23 @@ class ItemTest extends TestCase
         $this->assertSame('some-label', $item->getKey());
         $this->assertNull($item->toArray()['key']);
     }
+
+    public function testIconAndBadge(): void
+    {
+        $item = (new Item('Inbox', '/inbox'))
+            ->setIcon('fa fa-inbox')
+            ->setBadge(5, 'bg-danger');
+
+        $this->assertSame('fa fa-inbox', $item->getIcon());
+        $this->assertSame('5', $item->getBadge());
+        $this->assertSame('bg-danger', $item->getBadgeType());
+
+        $array = $item->toArray();
+        $this->assertSame('fa fa-inbox', $array['icon']);
+        $this->assertSame('5', $array['badge']);
+        $this->assertSame('bg-danger', $array['badgeType']);
+
+        $item->setBadge(null);
+        $this->assertNull($item->getBadge());
+    }
 }

--- a/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
@@ -170,4 +170,15 @@ class Bootstrap5SidebarRendererTest extends TestCase
         $this->assertStringContainsString('href="/"', $result);
         $this->assertStringNotContainsString('id="menu-collapse-empty"', $result);
     }
+
+    public function testRendersIconAndBadge(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Inbox', '/inbox', ['icon' => 'fa fa-inbox', 'badge' => 3, 'badgeType' => 'bg-danger']);
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        $this->assertStringContainsString('<i class="fa fa-inbox" aria-hidden="true"></i> ', $result);
+        $this->assertStringContainsString('<span class="badge bg-danger">3</span>', $result);
+    }
 }

--- a/tests/TestCase/Renderer/BreadcrumbRendererTest.php
+++ b/tests/TestCase/Renderer/BreadcrumbRendererTest.php
@@ -36,4 +36,14 @@ class BreadcrumbRendererTest extends TestCase
         $this->assertStringNotContainsString('onload="alert(1)"', $result);
         $this->assertStringContainsString('aria-label="x&quot; onload=&quot;alert(1)"', $result);
     }
+
+    public function testRendersItemIcon(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/', ['active' => true, 'icon' => 'fa fa-home']);
+
+        $result = (new BreadcrumbRenderer())->render($menu);
+
+        $this->assertStringContainsString('<i class="fa fa-home" aria-hidden="true"></i> ', $result);
+    }
 }

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -165,4 +165,26 @@ class StringTemplateRendererTest extends TestCase
         $this->assertStringContainsString('self-item', $result);
         $this->assertStringContainsString('Admin', $result);
     }
+
+    public function testRendersIconAndBadge(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Inbox', '/inbox', ['icon' => 'fa fa-inbox', 'badge' => 5, 'badgeType' => 'bg-danger']);
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertStringContainsString('<i class="fa fa-inbox" aria-hidden="true"></i> ', $result);
+        $this->assertStringContainsString('<span class="badge bg-danger">5</span>', $result);
+    }
+
+    public function testEscapesIconAndBadge(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('X', '/x', ['icon' => '"><script>', 'badge' => '<b>']);
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringNotContainsString('<b>', $result);
+    }
 }

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -392,4 +392,19 @@ class MenuHelperTest extends TestCase
 
         $this->assertSame('Visible', $menuHelper->getCurrentItem($menu, ['singleActive' => true])?->getLabel());
     }
+
+    public function testSingleActiveAffectsBreadcrumbs(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest(['url' => '/articles']));
+        $menu = Menu::create();
+        $parent = $menu->addItem('Section', '/articles');
+        $parent->getSubMenu()->addItem('Articles', '/articles');
+
+        $crumbs = $menuHelper->getBreadcrumbs($menu, ['singleActive' => true]);
+
+        // Breadcrumbs follow the deepest match's trail, not just the first match.
+        $this->assertCount(2, $crumbs);
+        $this->assertSame('Section', $crumbs[0]['title']);
+        $this->assertSame('Articles', $crumbs[1]['title']);
+    }
 }

--- a/tests/TestCase/View/Helper/MenuHelperTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperTest.php
@@ -349,4 +349,47 @@ class MenuHelperTest extends TestCase
         $this->expectExceptionMessage('additionalResolvers');
         $menuHelper->render($menu, ['additionalResolvers' => ['not-a-resolver']]);
     }
+
+    public function testReturnsFirstMatchWithoutSingleActive(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest(['url' => '/articles']));
+        $menu = Menu::create();
+        $parent = $menu->addItem('Section', '/articles');
+        $parent->getSubMenu()->addItem('Articles', '/articles');
+
+        // Both items match; the default returns the first (shallowest) match.
+        $this->assertSame('Section', $menuHelper->getCurrentItem($menu)?->getLabel());
+    }
+
+    public function testSingleActivePrefersDeepestMatch(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest(['url' => '/articles']));
+        $menu = Menu::create();
+        $parent = $menu->addItem('Section', '/articles');
+        $parent->getSubMenu()->addItem('Articles', '/articles');
+
+        $this->assertSame('Articles', $menuHelper->getCurrentItem($menu, ['singleActive' => true])?->getLabel());
+    }
+
+    public function testSingleActiveSkipsHiddenMatches(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest(['url' => '/articles']));
+        $menu = Menu::create();
+        $parent = $menu->addItem('Section', '/articles');
+        $parent->getSubMenu()->addItem('Hidden', '/articles', ['visible' => false]);
+
+        // The deeper match is hidden, so the visible parent stays the active item.
+        $this->assertSame('Section', $menuHelper->getCurrentItem($menu, ['singleActive' => true])?->getLabel());
+    }
+
+    public function testSingleActiveClearsEarlierHiddenMatch(): void
+    {
+        $menuHelper = $this->createHelper(new ServerRequest(['url' => '/articles']));
+        $menu = Menu::create();
+        // A hidden active item appears before the visible match in document order.
+        $menu->addItem('HiddenFirst', '/articles', ['visible' => false]);
+        $menu->addItem('Visible', '/articles');
+
+        $this->assertSame('Visible', $menuHelper->getCurrentItem($menu, ['singleActive' => true])?->getLabel());
+    }
 }


### PR DESCRIPTION
## Summary

Two menu enhancements, each with tests and docs.

### First-class icons & badges
Items gain `setIcon()` / `setBadge()` (and `icon` / `badge` / `badgeType` options), rendered and escaped around the label by every bundled renderer (string template, Bootstrap 5, Bootstrap 5 sidebar):

```php
$menu->addItem('Inbox', $url)->setIcon('fa fa-inbox')->setBadge(5, 'bg-danger');
```

The accessors live on the concrete `Item` (not `ItemInterface`) so the published interface stays backwards compatible; renderers guard with `instanceof`. Markup is overridable per render via the `iconTemplate` / `badgeTemplate` options.

### `singleActive` best-match arbitration
When several items resolve active for one request (e.g. a parent and a child pointing at the same route), `getCurrentItem()` / breadcrumbs previously followed the first DFS match. `singleActive` keeps only the **deepest visible** match active (tie-break by document order) and deactivates the rest — including hidden ones, so the active trail is always a single, rendered item:

```php
echo $this->Menu->render('main', ['singleActive' => true]);
```

Both default off, so existing output is unchanged.
