### PR TITLE
Add NavbarRenderer (full Bootstrap 5 navbar) and rootClass option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -368,6 +368,25 @@ Each branch is wired to its `collapse` element through a unique id, so it works 
 Bootstrap bundle and needs no custom JavaScript. Item and submenu attributes from the menu
 definition are preserved on the `<li>` and nested `<ul>`.
 
+Full Bootstrap 5 navbar — the complete `<nav>` chrome (brand, responsive toggler, and the
+collapsible `navbar-nav` with dropdowns), rather than just the inner `<ul>`:
+
+```php
+echo $this->Menu->render('main', [
+    'renderer' => \Menu\Renderer\NavbarRenderer::class,
+    'brand' => 'MyApp',
+    'brandUrl' => '/',
+    'expand' => 'lg',                 // navbar-expand-lg (collapse breakpoint)
+    'theme' => 'bg-body-tertiary',
+    'containerClass' => 'container-fluid',
+    'collapseId' => 'navbarNav',      // set per navbar if you have more than one on a page
+]);
+```
+
+`NavbarRenderer` generates the toggler/collapse wiring (matching `data-bs-target`, `id`, and
+`aria-controls`) for you. For just the `<ul class="navbar-nav">` to drop inside your own navbar
+markup, use `Bootstrap5Renderer` directly.
+
 A branch that only groups children (placeholder link `#`/none) renders a single toggle. A branch
 that *also* has a real URL stays navigable: it renders the link plus a separate collapse toggle
 button (`data-bs-target`), so the destination is reachable and its link attributes are kept.
@@ -428,6 +447,7 @@ BS4/other setups work without subclassing: `linkClass` (`nav-link`, top-level li
 | `leafClass` | `null` | Class for items without a submenu. |
 | `dividerClass` | `divider` | Class for divider items. |
 | `nestedMenuClass` | `submenu` | Class added to nested `<ul>` elements. |
+| `rootClass` | `null` | Class appended to the root (level 1) `<ul>` only. |
 | `menuLevelClass` | `null` | Prefix for a per-level class (e.g. `level-` produces `level-1`, `level-2`). |
 | `firstClass` / `lastClass` | `null` | Class for the first / last item in a list. |
 | `depth` | `null` | Maximum number of levels to render (`null` = unlimited). |

--- a/src/Renderer/NavbarRenderer.php
+++ b/src/Renderer/NavbarRenderer.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Renderer;
+
+use Menu\MenuInterface;
+use function htmlspecialchars;
+use function sprintf;
+use function trim;
+use const ENT_QUOTES;
+
+/**
+ * Renders a complete Bootstrap 5 navbar: the `<nav>` wrapper, optional brand, the responsive
+ * toggler, and the collapsible `navbar-nav` list (with dropdowns inherited from
+ * {@see \Menu\Renderer\Bootstrap5Renderer}).
+ *
+ * For just the `<ul class="navbar-nav">` (to place inside your own navbar chrome), use
+ * `Bootstrap5Renderer` directly.
+ */
+class NavbarRenderer extends Bootstrap5Renderer
+{
+    /**
+     * Counter used to generate unique collapse ids when none is provided.
+     */
+    protected static int $collapseInstances = 0;
+
+    /**
+     * @phpstan-param array<string, mixed> $config
+     */
+    public function __construct(array $config = [])
+    {
+        // User config wins; everything else falls back to these navbar defaults. Bootstrap 5
+        // link/dropdown defaults are inherited from Bootstrap5Renderer's config.
+        parent::__construct($config + [
+            'rootClass' => 'navbar-nav',
+            'expand' => 'lg',
+            'theme' => 'bg-body-tertiary',
+            'navbarClass' => null,
+            'containerClass' => 'container-fluid',
+            'brand' => null,
+            'brandUrl' => '/',
+            'togglerLabel' => 'Toggle navigation',
+        ]);
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function render(MenuInterface $menu, array $options = []): string
+    {
+        // The <nav> is the navigation landmark, so the aria-label belongs there, not on the
+        // inner <ul>. Capture it, then suppress it for the inner render.
+        $ariaLabel = $this->getStringOption($options, 'ariaLabel');
+        $options['ariaLabel'] = null;
+
+        $nav = parent::render($menu, $options);
+
+        $collapseId = $this->getStringOption($options, 'collapseId');
+        if ($collapseId === '') {
+            $collapseId = 'navbar-collapse-' . (++static::$collapseInstances);
+        }
+
+        $navAttributes = sprintf('class="%s"', $this->attribute($this->navbarClass($options)));
+        if ($ariaLabel !== '') {
+            $navAttributes .= sprintf(' aria-label="%s"', $this->attribute($ariaLabel));
+        }
+
+        return sprintf(
+            '<nav %s><div class="%s">%s%s<div class="collapse navbar-collapse" id="%s">%s</div></div></nav>',
+            $navAttributes,
+            $this->attribute($this->getStringOption($options, 'containerClass') ?: 'container-fluid'),
+            $this->brand($options),
+            $this->toggler($collapseId, $options),
+            $this->attribute($collapseId),
+            $nav,
+        );
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function navbarClass(array $options): string
+    {
+        $class = $this->getStringOption($options, 'navbarClass');
+        if ($class !== '') {
+            return $class;
+        }
+
+        $expand = $this->getStringOption($options, 'expand');
+        $theme = $this->getStringOption($options, 'theme');
+
+        return trim('navbar' . ($expand !== '' ? ' navbar-expand-' . $expand : '') . ($theme !== '' ? ' ' . $theme : ''));
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function brand(array $options): string
+    {
+        $brand = $this->getStringOption($options, 'brand');
+        if ($brand === '') {
+            return '';
+        }
+
+        return sprintf(
+            '<a class="navbar-brand" href="%s">%s</a>',
+            $this->attribute($this->getStringOption($options, 'brandUrl') ?: '/'),
+            htmlspecialchars($brand, ENT_QUOTES, 'UTF-8'),
+        );
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    protected function toggler(string $collapseId, array $options): string
+    {
+        $label = $this->getStringOption($options, 'togglerLabel') ?: 'Toggle navigation';
+
+        return sprintf(
+            '<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#%s"'
+            . ' aria-controls="%s" aria-expanded="false" aria-label="%s">'
+            . '<span class="navbar-toggler-icon"></span></button>',
+            $this->attribute($collapseId),
+            $this->attribute($collapseId),
+            htmlspecialchars($label, ENT_QUOTES, 'UTF-8'),
+        );
+    }
+
+    protected function attribute(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -39,6 +39,8 @@ class StringTemplateRenderer implements RendererInterface
         'submenuClass' => null,
         'hideEmptyBranches' => false,
         'nestedMenuClass' => 'submenu',
+        // Class appended to the root (level 1) <ul> only; off by default.
+        'rootClass' => null,
         'menuLevelClass' => null,
         'firstClass' => null,
         'lastClass' => null,
@@ -117,6 +119,11 @@ class StringTemplateRenderer implements RendererInterface
             $nestedMenuClass = $this->getStringOption($options, 'nestedMenuClass');
             if ($nestedMenuClass !== '') {
                 $attributes = $this->appendClass($attributes, $nestedMenuClass);
+            }
+        } else {
+            $rootClass = $this->getStringOption($options, 'rootClass');
+            if ($rootClass !== '') {
+                $attributes = $this->appendClass($attributes, $rootClass);
             }
         }
 

--- a/tests/TestCase/Renderer/NavbarRendererTest.php
+++ b/tests/TestCase/Renderer/NavbarRendererTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Renderer;
+
+use Cake\TestSuite\TestCase;
+use Menu\Menu;
+use Menu\Renderer\NavbarRenderer;
+
+class NavbarRendererTest extends TestCase
+{
+    public function testRendersFullNavbarChrome(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+        $account = $menu->addItem('Account', '#');
+        $account->getSubMenu()->addItem('Profile', '/profile');
+
+        $result = (new NavbarRenderer())->render($menu, [
+            'brand' => 'MyApp',
+            'brandUrl' => '/',
+            'collapseId' => 'navbarNav',
+        ]);
+
+        $this->assertStringContainsString('<nav class="navbar navbar-expand-lg bg-body-tertiary">', $result);
+        $this->assertStringContainsString('<div class="container-fluid">', $result);
+        $this->assertStringContainsString('<a class="navbar-brand" href="/">MyApp</a>', $result);
+        $this->assertStringContainsString('<button class="navbar-toggler"', $result);
+        // Toggler, target and collapse id all agree.
+        $this->assertStringContainsString('data-bs-target="#navbarNav"', $result);
+        $this->assertStringContainsString('aria-controls="navbarNav"', $result);
+        $this->assertStringContainsString('<div class="collapse navbar-collapse" id="navbarNav">', $result);
+        // The inner list is a navbar-nav with nav-link items and a dropdown branch.
+        $this->assertStringContainsString('<ul class="navbar-nav">', $result);
+        $this->assertStringContainsString('class="nav-link"', $result);
+        $this->assertMatchesRegularExpression('/class="[^"]*dropdown[^"]*"/', $result);
+    }
+
+    public function testOmitsBrandWhenNotProvided(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+
+        $result = (new NavbarRenderer())->render($menu);
+
+        $this->assertStringNotContainsString('navbar-brand', $result);
+    }
+
+    public function testCustomExpandThemeAndCollapseId(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+
+        $result = (new NavbarRenderer())->render($menu, [
+            'expand' => 'md',
+            'theme' => 'bg-dark',
+            'collapseId' => 'mainNav',
+            'containerClass' => 'container',
+        ]);
+
+        $this->assertStringContainsString('<nav class="navbar navbar-expand-md bg-dark">', $result);
+        $this->assertStringContainsString('<div class="container">', $result);
+        $this->assertStringContainsString('id="mainNav"', $result);
+        $this->assertStringContainsString('data-bs-target="#mainNav"', $result);
+    }
+
+    public function testEscapesBrand(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+
+        $result = (new NavbarRenderer())->render($menu, ['brand' => '<b>x</b>']);
+
+        $this->assertStringNotContainsString('<b>x</b>', $result);
+    }
+
+    public function testGeneratesUniqueCollapseIdsForMultipleNavbars(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+        $renderer = new NavbarRenderer();
+
+        $first = $renderer->render($menu);
+        $second = $renderer->render($menu);
+
+        preg_match('/<div class="collapse navbar-collapse" id="(navbar-collapse-\d+)">/', $first, $m1);
+        preg_match('/<div class="collapse navbar-collapse" id="(navbar-collapse-\d+)">/', $second, $m2);
+        $id1 = $m1[1] ?? '';
+        $id2 = $m2[1] ?? '';
+
+        $this->assertNotSame('', $id1);
+        $this->assertNotSame($id1, $id2);
+        // Each toggler targets its own collapse region.
+        $this->assertStringContainsString('data-bs-target="#' . $id1 . '"', $first);
+        $this->assertStringContainsString('data-bs-target="#' . $id2 . '"', $second);
+    }
+
+    public function testAriaLabelLabelsTheNavLandmarkNotTheList(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+
+        $result = (new NavbarRenderer())->render($menu, ['ariaLabel' => 'Primary', 'collapseId' => 'x']);
+
+        $this->assertStringContainsString('<nav class="navbar navbar-expand-lg bg-body-tertiary" aria-label="Primary">', $result);
+        // The inner list is not labelled (no aria-label on the <ul>).
+        $this->assertStringContainsString('<ul class="navbar-nav">', $result);
+    }
+}

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -165,4 +165,17 @@ class StringTemplateRendererTest extends TestCase
         $this->assertStringContainsString('self-item', $result);
         $this->assertStringContainsString('Admin', $result);
     }
+
+    public function testRootClassAppliesToTheRootListOnly(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '#');
+        $parent->getSubMenu()->addItem('Child', '/child');
+
+        $result = (new StringTemplateRenderer())->render($menu, ['rootClass' => 'navbar-nav']);
+
+        $this->assertStringContainsString('<ul class="navbar-nav">', $result);
+        // Nested lists keep their nestedMenuClass and are not given the root class.
+        $this->assertStringContainsString('<ul class="submenu">', $result);
+    }
 }


### PR DESCRIPTION
## Summary

A `NavbarRenderer` that emits the **full Bootstrap 5 navbar chrome**, plus a small reusable `rootClass` option.

`Bootstrap5Renderer` gives you the inner `<ul class="navbar-nav">`; `NavbarRenderer` wraps it in the complete landmark:

```php
echo $this->Menu->render('main', [
    'renderer' => \Menu\Renderer\NavbarRenderer::class,
    'brand' => 'MyApp',
    'expand' => 'lg',
    'theme' => 'bg-body-tertiary',
]);
```

It generates the brand, the responsive toggler, and the collapsible region — keeping `data-bs-target` / `id` / `aria-controls` in sync. Each navbar without an explicit `collapseId` gets a unique generated id (so multiple navbars on a page stay valid), and `ariaLabel` labels the `<nav>` landmark rather than the inner list.

### `rootClass` option
Appends a class to the root (level 1) `<ul>` only (nested lists untouched) — how `NavbarRenderer` applies `navbar-nav`, and useful for any wrapper that needs a class on the top-level list.

> [!NOTE]
> Icons/badges (#10) flow through `NavbarRenderer` automatically once that PR merges, since it extends `Bootstrap5Renderer`.
