### PR TITLE
Add non-link section headers (group labels)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,22 @@ $products->add($menu->newItem('Books', ['controller' => 'Products', 'action' => 
 $products->add($menu->newItem('Games', ['controller' => 'Products', 'action' => 'games']));
 ```
 
+### Section Headers and Dividers
+
+Group items under a non-link header, and separate groups with a divider:
+
+```php
+$menu->addHeader('Account');
+$menu->addItem('Profile', '/profile');
+$menu->addItem('Logout', '/logout');
+$menu->addDivider();
+$menu->addHeader('Admin');
+$menu->addItem('Users', ['prefix' => 'Admin', 'controller' => 'Users', 'action' => 'index']);
+```
+
+A header renders as a plain `<li>` with the `headerClass` (`menu-header`, or `nav-header` in the
+sidebar renderer), not a link.
+
 ### Named Menus via Helper
 
 ```php
@@ -78,6 +94,7 @@ $this->Menu->register('main', static function ($menu): void {
 - `fuzzy`: enables subset matching for Cake array routes
 - `raw`: render raw HTML inside the item
 - `divider`: render a divider item
+- `header`: render a non-link section header (or use `Menu::addHeader()`)
 - `expanded`: runtime state for open branches
 
 ## Import / Export
@@ -427,6 +444,7 @@ BS4/other setups work without subclassing: `linkClass` (`nav-link`, top-level li
 | `submenuClass` | `null` | Extra class for branch items, in addition to `branchClass`. |
 | `leafClass` | `null` | Class for items without a submenu. |
 | `dividerClass` | `divider` | Class for divider items. |
+| `headerClass` | `menu-header` | Class for non-link section headers (`nav-header` in the sidebar renderer). |
 | `nestedMenuClass` | `submenu` | Class added to nested `<ul>` elements. |
 | `menuLevelClass` | `null` | Prefix for a per-level class (e.g. `level-` produces `level-1`, `level-2`). |
 | `firstClass` / `lastClass` | `null` | Class for the first / last item in a list. |

--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -29,6 +29,8 @@ class Item implements ItemInterface, StateResetInterface
 
     protected bool $divider = false;
 
+    protected bool $header = false;
+
     protected bool $visible = true;
 
     protected bool $defaultVisible = true;
@@ -193,6 +195,19 @@ class Item implements ItemInterface, StateResetInterface
     public function isDivider(): bool
     {
         return $this->divider;
+    }
+
+    public function setHeader(bool $header = true): static
+    {
+        $this->assertMutable();
+        $this->header = $header;
+
+        return $this;
+    }
+
+    public function isHeader(): bool
+    {
+        return $this->header;
     }
 
     public function setVisibility(bool $isVisible): static
@@ -447,6 +462,7 @@ class Item implements ItemInterface, StateResetInterface
             'external' => $this->link?->isExternal() ?? false,
             'raw' => $this->raw,
             'divider' => $this->divider,
+            'header' => $this->header,
             'visible' => $this->visible,
             'active' => $this->active,
             'expanded' => $this->expanded,

--- a/src/Item/ItemInterface.php
+++ b/src/Item/ItemInterface.php
@@ -42,6 +42,10 @@ interface ItemInterface
 
     public function isDivider(): bool;
 
+    public function setHeader(bool $header = true): static;
+
+    public function isHeader(): bool;
+
     public function setVisibility(bool $isVisible): static;
 
     public function isVisible(): bool;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -82,6 +82,7 @@ class Menu implements MenuInterface
                     'active' => $itemConfig['active'] ?? false,
                     'raw' => $itemConfig['raw'] ?? null,
                     'divider' => $itemConfig['divider'] ?? false,
+                    'header' => $itemConfig['header'] ?? false,
                     'submenuAttributes' => $itemConfig['submenu']['attributes'] ?? [],
                     'matchRoutes' => $itemConfig['matchRoutes'] ?? [],
                     'ignoreQueryString' => $itemConfig['ignoreQueryString'] ?? null,
@@ -165,6 +166,20 @@ class Menu implements MenuInterface
     }
 
     /**
+     * Adds a non-link section header (a group label).
+     *
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function addHeader(string $label, array $options = []): ItemInterface
+    {
+        $item = $this->newItem($label, null, $options);
+        $item->setHeader();
+        $this->add($item);
+
+        return $item;
+    }
+
+    /**
      * @phpstan-param \Menu\Link\LinkInterface|array<string|int, mixed>|string|null $link
      * @phpstan-param array<string, mixed> $options
      */
@@ -210,6 +225,9 @@ class Menu implements MenuInterface
         }
         if (!empty($options['divider'])) {
             $item->setDivider();
+        }
+        if (!empty($options['header'])) {
+            $item->setHeader();
         }
         if (isset($options['submenuAttributes']) && is_array($options['submenuAttributes'])) {
             $item->getSubMenu()->setAttributes($options['submenuAttributes']);

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -54,6 +54,11 @@ interface MenuInterface
     public function addDivider(array $options = []): ItemInterface;
 
     /**
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function addHeader(string $label, array $options = []): ItemInterface;
+
+    /**
      * @phpstan-param \Menu\Link\LinkInterface|array<string|int, mixed>|string|null $link
      * @phpstan-param array<string, mixed> $options
      */

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -125,6 +125,12 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
         if ($item->isDivider()) {
             return $this->li($item, $options, '<hr class="dropdown-divider">');
         }
+        if ($item->isHeader()) {
+            $attributes = $this->appendClass($item->getAttributes(), $this->getStringOption($options, 'headerClass') ?: 'nav-header');
+            $title = $item->getBefore() . $this->escapeLabel($item) . $item->getAfter();
+
+            return sprintf('<li%s>%s</li>', $this->renderAttributes($attributes), $title);
+        }
 
         $hasSubMenu = $item->hasSubMenu();
         if (

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -33,6 +33,7 @@ class StringTemplateRenderer implements RendererInterface
         'activeClass' => 'active',
         'ancestorClass' => 'active-ancestor',
         'dividerClass' => 'divider',
+        'headerClass' => 'menu-header',
         'branchClass' => 'has-children',
         'leafClass' => null,
         // Extra class for branch <li>s, in addition to `branchClass`; off by default.
@@ -53,6 +54,7 @@ class StringTemplateRenderer implements RendererInterface
             'link' => '<a{{attributes}}>{{title}}</a>',
             'label' => '<span{{attributes}}>{{title}}</span>',
             'divider' => '<li{{attributes}}></li>',
+            'header' => '<li{{attributes}}>{{title}}</li>',
         ],
     ];
 
@@ -155,6 +157,16 @@ class StringTemplateRenderer implements RendererInterface
 
             return $this->templater()->format('divider', [
                 'attributes' => $this->renderAttributes($attributes),
+            ]);
+        }
+
+        if ($item->isHeader()) {
+            $attributes = $this->applyPositionClasses($item->getAttributes(), $options, $index, $count);
+            $attributes = $this->appendConfiguredClass($attributes, $options, 'headerClass');
+
+            return $this->templater()->format('header', [
+                'attributes' => $this->renderAttributes($attributes),
+                'title' => $item->getBefore() . $this->escapeLabel($item) . $item->getAfter(),
             ]);
         }
 

--- a/tests/TestCase/Item/ItemTest.php
+++ b/tests/TestCase/Item/ItemTest.php
@@ -79,4 +79,15 @@ class ItemTest extends TestCase
         $this->assertSame('some-label', $item->getKey());
         $this->assertNull($item->toArray()['key']);
     }
+
+    public function testHeaderFlag(): void
+    {
+        $item = (new Item('Account'))->setHeader();
+
+        $this->assertTrue($item->isHeader());
+        $this->assertTrue($item->toArray()['header']);
+
+        $item->setHeader(false);
+        $this->assertFalse($item->isHeader());
+    }
 }

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -225,4 +225,13 @@ class MenuTest extends TestCase
         $this->assertSame('profile', $collection->findByKey('profile')?->getKey());
         $this->assertCount(2, $collection->findByParent($account));
     }
+
+    public function testAddHeader(): void
+    {
+        $menu = Menu::create();
+        $menu->addHeader('Section');
+
+        $this->assertTrue($menu->getItems()[0]->toArray()['header']);
+        $this->assertSame('Section', $menu->getItems()[0]->getLabel());
+    }
 }

--- a/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
@@ -170,4 +170,16 @@ class Bootstrap5SidebarRendererTest extends TestCase
         $this->assertStringContainsString('href="/"', $result);
         $this->assertStringNotContainsString('id="menu-collapse-empty"', $result);
     }
+
+    public function testRendersSectionHeader(): void
+    {
+        $menu = Menu::create();
+        $menu->addHeader('Account');
+        $menu->addItem('Profile', '/profile');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        $this->assertStringContainsString('<li class="nav-header">Account</li>', $result);
+        $this->assertStringContainsString('href="/profile"', $result);
+    }
 }

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -165,4 +165,16 @@ class StringTemplateRendererTest extends TestCase
         $this->assertStringContainsString('self-item', $result);
         $this->assertStringContainsString('Admin', $result);
     }
+
+    public function testRendersSectionHeader(): void
+    {
+        $menu = Menu::create();
+        $menu->addHeader('Account');
+        $menu->addItem('Profile', '/profile');
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertStringContainsString('<li class="menu-header">Account</li>', $result);
+        $this->assertStringContainsString('<a href="/profile">Profile</a>', $result);
+    }
 }


### PR DESCRIPTION
## Summary

Non-link **section headers** (group labels) for menus.

```php
$menu->addHeader('Account');
$menu->addItem('Profile', '/profile');
$menu->addItem('Logout', '/logout');
```

- `setHeader()` / `isHeader()` on `ItemInterface`, `Menu::addHeader()` on `MenuInterface`, and a `header` item option.
- Rendered as a plain `<li>` with `headerClass` (`menu-header` by default, `nav-header` in the sidebar renderer) — not a link.
- Consistent with the existing `divider` / `raw` features (on the interfaces).
