### PR TITLE
Add Menu::fromFlat() for database-backed menus

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -631,6 +631,27 @@ $menu = Menu::fromArray(require CONFIG . 'menu.php');
 echo $this->Menu->render($menu);
 ```
 
+### Database-Backed Menus
+
+`Menu::fromFlat()` builds a tree from flat, parent-referenced rows (a `menu_items` table, an
+editable CMS nav, …). The mapper turns each row into a spec (`key`, `parent`, `label`, `link`, and
+any `newItem()` `options`); rows may be in any order, and unknown parents fall back to root:
+
+```php
+use Menu\Menu;
+
+$rows = $this->fetchTable('MenuItems')->find()->orderBy(['weight' => 'ASC'])->all();
+
+$menu = Menu::fromFlat($rows, fn ($row): array => [
+    'key' => (string)$row->id,
+    'parent' => $row->parent_id !== null ? (string)$row->parent_id : null,
+    'label' => $row->title,
+    'link' => $row->url,
+]);
+
+echo $this->Menu->render($menu);
+```
+
 ### Building Menus Once in AppView
 
 `register()` is idempotent, so define named menus once in `AppView::initialize()` and render them

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Menu;
 
+use Closure;
 use InvalidArgumentException;
 use LogicException;
 use Menu\Item\Item;
@@ -110,6 +111,80 @@ class Menu implements MenuInterface
         }
 
         return $menu;
+    }
+
+    /**
+     * Builds a menu from a flat list of rows (e.g. database records), linking children to parents.
+     *
+     * The mapper receives each row and returns a spec with `key`, optional `parent` (the key of the
+     * parent row, or `null` for a root item), `label`, `link`, and optional `options` (any
+     * `newItem()` option). Rows may arrive in any order; children are attached once all rows are
+     * read, and rows whose `parent` key is unknown are treated as root items.
+     *
+     * @phpstan-param iterable<mixed> $rows
+     * @phpstan-param \Closure(mixed): array<string, mixed> $mapper
+     */
+    public static function fromFlat(iterable $rows, Closure $mapper): static
+    {
+        $menu = static::create();
+        /** @var array<string, \Menu\Item\ItemInterface> $byKey */
+        $byKey = [];
+        /** @var list<array{item: \Menu\Item\ItemInterface, parent: string|null}> $pending */
+        $pending = [];
+
+        foreach ($rows as $row) {
+            $spec = $mapper($row);
+
+            $link = $spec['link'] ?? null;
+            if ($link !== null && !is_string($link) && !is_array($link) && !$link instanceof LinkInterface) {
+                $link = null;
+            }
+
+            $item = $menu->newItem(
+                isset($spec['label']) ? (string)$spec['label'] : null,
+                $link,
+                (array)($spec['options'] ?? []),
+            );
+
+            $key = isset($spec['key']) ? (string)$spec['key'] : '';
+            if ($key !== '') {
+                $item->setKey($key);
+                $byKey[$key] = $item;
+            }
+
+            $parent = isset($spec['parent']) ? (string)$spec['parent'] : null;
+            $pending[] = ['item' => $item, 'parent' => $parent];
+        }
+
+        foreach ($pending as $entry) {
+            $parent = $entry['parent'] !== null ? ($byKey[$entry['parent']] ?? null) : null;
+            if ($parent !== null && !static::wouldCycle($entry['item'], $parent)) {
+                $parent->add($entry['item']);
+
+                continue;
+            }
+            $menu->add($entry['item']);
+        }
+
+        return $menu;
+    }
+
+    /**
+     * Whether attaching $item under $parent would create a cycle — i.e. $parent is $item itself or
+     * already a descendant of $item (from a self-reference or a loop in the source data). Such an
+     * edge is dropped (the item becomes a root) so the tree stays acyclic and finite.
+     */
+    protected static function wouldCycle(ItemInterface $item, ItemInterface $parent): bool
+    {
+        $ancestor = $parent;
+        while ($ancestor !== null) {
+            if ($ancestor === $item) {
+                return true;
+            }
+            $ancestor = $ancestor->getParent();
+        }
+
+        return false;
     }
 
     public function add(ItemInterface $item): static

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Menu;
 
+use Closure;
 use Menu\Item\ItemInterface;
 use Menu\Link\LinkInterface;
 use Menu\Resolver\ResolverCollectionInterface;
@@ -30,6 +31,12 @@ interface MenuInterface
      * @phpstan-param array<string, mixed> $config
      */
     public static function fromArray(array $config): static;
+
+    /**
+     * @phpstan-param iterable<mixed> $rows
+     * @phpstan-param \Closure(mixed): array<string, mixed> $mapper
+     */
+    public static function fromFlat(iterable $rows, Closure $mapper): static;
 
     public function add(ItemInterface $item): static;
 

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -225,4 +225,64 @@ class MenuTest extends TestCase
         $this->assertSame('profile', $collection->findByKey('profile')?->getKey());
         $this->assertCount(2, $collection->findByParent($account));
     }
+
+    public function testFromFlatBuildsTreeFromUnorderedRows(): void
+    {
+        $rows = [
+            ['id' => 3, 'parent' => 1, 'title' => 'Profile', 'url' => '/profile'],
+            ['id' => 1, 'parent' => null, 'title' => 'Account', 'url' => '#'],
+            ['id' => 2, 'parent' => null, 'title' => 'Home', 'url' => '/'],
+            ['id' => 4, 'parent' => 1, 'title' => 'Logout', 'url' => '/logout'],
+        ];
+
+        $menu = Menu::fromFlat($rows, fn (array $row): array => [
+            'key' => (string)$row['id'],
+            'parent' => $row['parent'] !== null ? (string)$row['parent'] : null,
+            'label' => $row['title'],
+            'link' => $row['url'],
+        ]);
+
+        $this->assertCount(2, $menu->getItems());
+        $account = $menu->getItems()[0];
+        $this->assertSame('Account', $account->getLabel());
+        $this->assertSame('Home', $menu->getItems()[1]->getLabel());
+        $this->assertSame(['Profile', 'Logout'], [
+            $account->getSubMenu()->getItems()[0]->getLabel(),
+            $account->getSubMenu()->getItems()[1]->getLabel(),
+        ]);
+    }
+
+    public function testFromFlatTreatsUnknownParentAsRoot(): void
+    {
+        $menu = Menu::fromFlat(
+            [['id' => 5, 'parent' => 99, 'title' => 'Lost', 'url' => '/lost']],
+            fn (array $row): array => [
+                'key' => (string)$row['id'],
+                'parent' => (string)$row['parent'],
+                'label' => $row['title'],
+                'link' => $row['url'],
+            ],
+        );
+
+        $this->assertCount(1, $menu->getItems());
+        $this->assertSame('Lost', $menu->getItems()[0]->getLabel());
+    }
+
+    public function testFromFlatBreaksCyclicParentReferences(): void
+    {
+        $rows = [
+            ['id' => 1, 'parent' => 2, 'title' => 'A', 'url' => '/a'],
+            ['id' => 2, 'parent' => 1, 'title' => 'B', 'url' => '/b'],
+        ];
+
+        $menu = Menu::fromFlat($rows, fn (array $row): array => [
+            'key' => (string)$row['id'],
+            'parent' => (string)$row['parent'],
+            'label' => $row['title'],
+            'link' => $row['url'],
+        ]);
+
+        // The cycle is broken, so tree traversal terminates and keeps both items.
+        $this->assertCount(2, $menu->collect());
+    }
 }


### PR DESCRIPTION
## Summary

A `Menu::fromFlat()` for building a menu tree from **flat, parent-referenced rows** (a database table / editable CMS nav).

```php
$rows = $this->fetchTable('MenuItems')->find()->orderBy(['weight' => 'ASC'])->all();

$menu = Menu::fromFlat($rows, fn ($row): array => [
    'key' => (string)$row->id,
    'parent' => $row->parent_id !== null ? (string)$row->parent_id : null,
    'label' => $row->title,
    'link' => $row->url,
]);
```

- A mapper closure decouples the library from your column names and row type (entities or arrays).
- Rows may arrive in any order; children are linked after all rows are read.
- Unknown parents fall back to root, and **cyclic parent references are detected and broken** (the offending edge becomes a root) so recursive traversal stays finite.
