### PR TITLE
Add menu parity and infrastructure features

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Example configuration for dereuromark/cakephp-menu.
+ *
+ * Copy the keys you need into your application's config (e.g. `config/app_local.php`,
+ * `config/app.php`, or a dedicated `config/menu.php` loaded via `Configure::load('menu')`).
+ */
+
+return [
+    /*
+     * Menus declared in configuration. Each entry is keyed by menu name and is a
+     * `Menu::fromArray()` spec. The Menu helper auto-registers these on initialize, so they are
+     * renderable without any wiring:
+     *
+     *     echo $this->Menu->render('main');
+     *
+     * An explicit `$this->Menu->create('main')` / `register('main', ...)` in code overrides the
+     * configured menu of the same name.
+     */
+    'Menu' => [
+        'menus' => [
+            'main' => [
+                'attributes' => ['class' => 'nav'],
+                'items' => [
+                    ['label' => 'Home', 'link' => '/'],
+                    [
+                        'label' => 'Articles',
+                        'link' => ['controller' => 'Articles', 'action' => 'index'],
+                        'submenu' => [
+                            'items' => [
+                                ['label' => 'Latest', 'link' => ['controller' => 'Articles', 'action' => 'index', '?' => ['sort' => 'created']]],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+];

--- a/docs/guide/building.md
+++ b/docs/guide/building.md
@@ -123,6 +123,18 @@ $menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'])
 values yourself. The `label` is escaped unless you pass `escape => false`.
 :::
 
+Two more rendering-related options:
+
+```php
+// Render the item but not its submenu (treated as a leaf):
+$menu->addItem('Reports', '/reports', ['displayChildren' => false]);
+
+// Attributes on the rendered link/label element (classes merge with existing ones):
+$menu->addItem('Help', '/help', [
+    'labelAttributes' => ['title' => 'Get help', 'class' => 'text-muted'],
+]);
+```
+
 ## Import / Export
 
 Menu trees can be created from arrays and exported back:
@@ -159,15 +171,57 @@ Frozen menus still allow runtime state updates from resolvers such as `active`, 
 
 ## Item Lookup and Mutation
 
+Look items up by id or by key (explicit, or the slug of the label):
+
 ```php
-$menu->get('account');
+$menu->get('account');           // by id
 $menu->has('account');
 $menu->remove('account');
+
+$menu->getByKey('profile');      // by key (explicit or label slug)
+$menu->hasKey('profile');
+$menu->removeByKey('profile');   // removes the first match
+
 $menu->sortBy('weight');
 $menu->filter(fn ($item) => $item->isVisible());
 $menu->clearActive();
 $menu->getActiveItem();
 ```
+
+::: tip
+Key lookups match the explicit key or, if none was set, the label slug. When labels may collide,
+assign explicit keys (`['key' => 'profile']`) so operations target a specific item.
+:::
+
+## Tree Manipulation
+
+Reorder, insert, move, merge, and split a menu's direct items (by id or key):
+
+```php
+// Insert relative to a sibling:
+$menu->insertBefore($menu->newItem('New', '/new'), 'articles');
+$menu->insertAfter($menu->newItem('New', '/new'), 'home');
+
+// Move an existing item:
+$menu->moveToFirstPosition('account');
+$menu->moveToLastPosition('home');
+$menu->moveToPosition('articles', 2);
+
+// Reorder by id/key (unlisted items keep their order, appended after):
+$menu->reorder(['home', 'articles', 'account']);
+
+// Merge another menu's items in (a deep copy; the source menu is left intact):
+$menu->merge($otherMenu);
+
+// Derive new menus (e.g. for columns) — items are copied, the original is untouched:
+$firstTwo = $menu->slice(0, 2);
+['primary' => $left, 'secondary' => $right] = $menu->split(2);
+```
+
+::: info
+`slice()`, `split()`, and `merge()` copy items via the array round-trip, so the derived menu contains
+base `Item` objects (custom item classes are not preserved).
+:::
 
 ### Flattened Collection
 

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -96,35 +96,51 @@ visible.
 
 ## Caching Role-Based Menus
 
-Access checks are cheap, but for a large ACL menu you can resolve visibility once per role-set and
-cache the filtered tree. Active-state is request-specific, so cache the *structure*, not the HTML:
+Access checks are cheap, but for a large ACL menu you can build and visibility-filter the tree once
+per role-set and cache its *structure* (active state is request-specific and always resolved fresh).
+The simplest way is the helper's built-in `cache` option on `register()`, keyed per role-set:
 
 ```php
-use Cake\Cache\Cache;
 use Menu\Item\ItemInterface;
-use Menu\Menu;
+use Menu\MenuInterface;
 use Menu\Resolver\AuthorizationResolver;
 
 $cacheKey = 'menu_main_' . implode('-', $this->AuthUser->roles());
-$tree = Cache::read($cacheKey);
-if ($tree === null) {
-    $menu = $this->Menu->create('main');
-    // ...addItem() calls...
 
+$this->Menu->register('main', function (MenuInterface $menu): void {
+    // ...addItem() calls...
     $menu->resolve(new AuthorizationResolver(function (ItemInterface $item): ?bool {
         $url = $item->getLink()?->getRawUrl();
 
         return is_array($url) ? $this->AuthUser->hasAccess($url) : null;
     }));
     $menu->filter(static fn (ItemInterface $item): bool => $item->isVisible());
+}, ['cache' => ['key' => $cacheKey, 'config' => 'long']]);
 
+// The build callback runs once per role-set; rendering re-resolves active state per request.
+echo $this->Menu->render('main');
+```
+
+::: details Managing the cache manually
+
+If you'd rather control the cache yourself, cache `toArray()` and rebuild with `Menu::fromArray()`:
+
+```php
+use Cake\Cache\Cache;
+use Menu\Menu;
+
+$tree = Cache::read($cacheKey);
+if ($tree === null) {
+    $menu = $this->Menu->create('main');
+    // ...build, resolve visibility, filter...
     $tree = $menu->toArray();
     Cache::write($cacheKey, $tree);
 }
 
-// Rendering re-resolves active-state for the current request.
 echo $this->Menu->render(Menu::fromArray($tree));
 ```
+
+:::
 
 ## TinyAuth Backend Navigation
 
@@ -166,18 +182,30 @@ and `raw` are still emitted as trusted markup — cast or escape dynamic values 
 
 ## Defining a Menu in Config
 
-`Menu::fromArray()` accepts the same shape `toArray()` produces, so a menu can live in a config file:
+The helper auto-registers menus declared under `Configure::read('Menu.menus')` (each a
+`Menu::fromArray()` spec keyed by name), so a config-defined menu renders without any wiring:
 
 ```php
-// config/menu.php
-return [
-    'attributes' => ['class' => 'nav'],
-    'items' => [
-        ['label' => 'Home', 'link' => '/'],
-        ['label' => 'Articles', 'link' => ['controller' => 'Articles', 'action' => 'index']],
+// config/app.php (or a dedicated config/menu.php loaded with Configure::load('menu'))
+'Menu' => [
+    'menus' => [
+        'main' => [
+            'attributes' => ['class' => 'nav'],
+            'items' => [
+                ['label' => 'Home', 'link' => '/'],
+                ['label' => 'Articles', 'link' => ['controller' => 'Articles', 'action' => 'index']],
+            ],
+        ],
     ],
-];
+],
 ```
+
+```php
+echo $this->Menu->render('main'); // no create()/register() needed
+```
+
+An explicit `create()`/`register()` of the same name overrides the configured menu. To build a menu
+from an arbitrary array yourself, `Menu::fromArray()` accepts the same shape `toArray()` produces:
 
 ```php
 use Menu\Menu;

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -151,6 +151,19 @@ Pass options per render call, as constructor config, or via `setConfig()`.
 (`linkClass`, `childLinkClass`, `toggleClass`, `toggleAttribute`, `toggleValue`) so Bootstrap 4 or
 other setups work without subclassing.
 
+### WAI-ARIA menu roles
+
+By default the renderers emit `aria-current`/`aria-expanded`/`aria-label`. For the full WAI-ARIA menu
+pattern, opt in with `roles => true`:
+
+```php
+echo $this->Menu->render('main', ['roles' => true]);
+```
+
+This adds `role="menubar"` (root) / `role="menu"` (nested) on the lists, `role="none"` on items,
+`role="menuitem"` (plus `aria-haspopup="true"` on branches) on links, and `role="separator"` /
+`role="presentation"` on dividers / headers. It is off by default so existing markup is unchanged.
+
 ## Good to know
 
 ::: warning Escaping

--- a/docs/guide/resolvers.md
+++ b/docs/guide/resolvers.md
@@ -59,6 +59,25 @@ $menu->addItem('Admin Articles', '/admin/articles', [
 $menu->resolve(new SectionResolver($request));
 ```
 
+## Regex Resolver
+
+`RegexResolver` activates items whose regular expression (stored in `data['match']`) matches the
+current request path — handy for lighting up a whole URL section that a route-array match can't
+express. A value may be a single pattern or a list; invalid patterns are ignored.
+
+```php
+use Menu\Resolver\RegexResolver;
+
+$menu->addItem('Admin', '/admin', [
+    'data' => ['match' => '#^/admin/(users|roles)#'],
+]);
+
+$menu->resolve(new RegexResolver($request->getUri()->getPath()));
+```
+
+Pass a second argument to read patterns from a different data key, e.g.
+`new RegexResolver($path, 'activePattern')`.
+
 ## Login Visibility Resolver
 
 Mark items with metadata:

--- a/docs/reference/cheatsheet.md
+++ b/docs/reference/cheatsheet.md
@@ -28,6 +28,13 @@ Menu::fromFlat(iterable $rows, Closure $mapper): static  // build a tree from fl
 | `getItems()` / `setItems(array)` | Root items as an array. |
 | `collect()` | All items (root + descendants) as an `ItemCollection`. |
 | `get(string $id)` / `has(string $id)` / `remove(string $id)` | Find/check/remove by id (recursive). |
+| `getByKey(string $key)` / `hasKey(string $key)` / `removeByKey(string $key)` | Find/check/remove by key — explicit or label slug; targets the first match (recursive). |
+| `insertBefore(ItemInterface $item, string $idOrKey)` / `insertAfter(...)` | Insert relative to a sibling (by id/key). |
+| `moveToPosition(string $idOrKey, int $pos)` / `moveToFirstPosition(...)` / `moveToLastPosition(...)` | Reposition a child. |
+| `reorder(list<string> $order)` | Reorder children by id/key; unlisted keep order, appended. |
+| `merge(MenuInterface $menu, bool $mergeAttributes = false)` | Append a deep copy of another menu's items (source untouched). |
+| `slice(int\|string $offset, int\|string\|null $length = null)` | New menu with a copy of a range of items. |
+| `split(int\|string $length)` | `['primary' => ..., 'secondary' => ...]` menus split at a boundary. |
 | `getActiveItem()` | Deepest active item. |
 | `clearActive()` | Deactivate all items. |
 | `getAttributes()` / `setAttribute()` / `setAttributes()` | Root HTML attributes. |
@@ -52,7 +59,8 @@ A single entry. (`ItemInterface`)
 | Type | `setDivider()` / `isDivider()`, `setHeader()` / `isHeader()` |
 | Icon/badge | `setIcon()` / `getIcon()`, `setBadge($badge, $type)` / `getBadge()` / `getBadgeType()` |
 | State | `setActive()` / `isActive()`, `setVisibility()` / `isVisible()`, `setExpanded()` / `isExpanded()` |
-| Submenu | `add()`, `setSubMenu()` / `getSubMenu()` / `hasSubMenu()` |
+| Submenu | `add()`, `setSubMenu()` / `getSubMenu()` / `hasSubMenu()`, `setDisplayChildren(bool)` / `displaysChildren()` |
+| Label attrs | `setLabelAttributes(array, bool $merge = false)` / `getLabelAttributes()` |
 | Tree | `setParent()` / `getParent()` / `hasParent()` / `getParentId()` |
 | Matching | `setMatchRoutes()` / `addMatchRoute()` / `getMatchRoutes()`, `setIgnoreQueryString()` / `getIgnoreQueryString()`, `setFuzzyMatch()` / `isFuzzyMatch()` |
 | Attributes/data | `setAttribute()` / `setAttributes()` / `getAttributes()`, `setData()` / `getData()` |

--- a/docs/reference/helper-options.md
+++ b/docs/reference/helper-options.md
@@ -62,9 +62,53 @@ them and add your own, use `additionalResolvers`. See [Resolvers](/guide/resolve
 | `attributes` / `menuAttributes` | HTML attributes for the root `<ul>`. |
 | `overwrite` | Allow `create()` to replace an existing menu of the same name. |
 | `rebuild` | Make `register()` rebuild even if the menu already exists. |
+| `cache` | Cache the built structure (see below). `true`, a string key, or `['key' => ..., 'config' => ...]`. |
 
 Any other keys (e.g. `renderer`, `singleActive`) set here become defaults for later `render()` calls
 on that menu.
+
+### Caching a built menu
+
+`register()` with a `cache` option builds the menu through the callback once and caches its
+**structure** (not its active state); later requests skip the build and load the tree from cache,
+while active state is always resolved fresh per request. Pass `rebuild => true` to refresh.
+
+```php
+$this->Menu->register('main', function ($menu): void {
+    // ...expensive build, e.g. a DB/ACL query...
+}, ['cache' => 'menu_main']); // or ['cache' => true] (keyed by menu name), or ['key' => ..., 'config' => ...]
+```
+
+::: warning
+The cached form is the serialized array, so custom item classes are restored as the base item class.
+Cache data-driven menus, not menus that rely on custom `ItemInterface` implementations.
+:::
+
+## Config-defined menus
+
+The helper auto-registers menus declared in `Configure::read('Menu.menus')` (each value a
+`Menu::fromArray()` spec keyed by name), so they render without any wiring:
+
+```php
+// config/app.php (or a dedicated config/menu.php loaded via Configure::load)
+'Menu' => [
+    'menus' => [
+        'main' => [
+            'attributes' => ['class' => 'nav'],
+            'items' => [
+                ['label' => 'Home', 'link' => '/'],
+                ['label' => 'Articles', 'link' => ['controller' => 'Articles', 'action' => 'index']],
+            ],
+        ],
+    ],
+],
+```
+
+```php
+echo $this->Menu->render('main'); // no create()/register() needed
+```
+
+An explicit `create()`/`register()` of the same name overrides the configured menu entirely.
 
 ## Breadcrumb options
 

--- a/docs/reference/item-options.md
+++ b/docs/reference/item-options.md
@@ -44,6 +44,8 @@ $menu->addItem('Inbox', ['controller' => 'Messages', 'action' => 'index'], [
 | `ignoreQueryString` | `bool\|null` | `null` | Ignore the query string when matching (overrides the resolver default). |
 | `fuzzy` | `bool` | `false` | Enable fuzzy (prefix) route matching for this item. |
 | `expanded` | `bool` | `false` | Show the submenu expanded by default. |
+| `displayChildren` | `bool` | `true` | When `false`, render the item but not its submenu (treated as a leaf). |
+| `labelAttributes` | `array` | `[]` | HTML attributes on the rendered link/label element (classes merge). |
 
 ::: warning Trusted markup
 `before`, `after`, `raw`, and the icon/badge markup are emitted **as-is** — they are not escaped.
@@ -84,5 +86,7 @@ $item = $menu->addItem('Profile', '/profile')
 | `ignoreQueryString` | `setIgnoreQueryString()` |
 | `fuzzy` | `setFuzzyMatch()` |
 | `expanded` | `setExpanded()` |
+| `displayChildren` | `setDisplayChildren()` |
+| `labelAttributes` | `setLabelAttributes()` |
 
 See the full method list in the [API Cheat Sheet](/reference/cheatsheet#item).

--- a/docs/reference/renderer-options.md
+++ b/docs/reference/renderer-options.md
@@ -48,6 +48,7 @@ The dependency-free default.
 | `ariaLabel` | `null` | Optional `aria-label` on the root menu. |
 | `addAriaCurrent` | `true` | Add `aria-current="page"` to active items. |
 | `addAriaExpanded` | `true` | Add `aria-expanded` to branch toggles. |
+| `roles` | `false` | Opt-in WAI-ARIA menu roles: `menubar`/`menu` on lists, `none` on items, `menuitem` (+ `aria-haspopup` on branches) on links, `separator`/`presentation` on dividers/headers. |
 
 ### Template keys
 

--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -76,6 +76,13 @@ class Item implements ItemInterface, StateResetInterface
 
     protected bool $defaultExpanded = false;
 
+    protected bool $displayChildren = true;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $labelAttributes = [];
+
     protected bool $frozen = false;
 
     /**
@@ -473,6 +480,38 @@ class Item implements ItemInterface, StateResetInterface
         return $this->expanded;
     }
 
+    public function setDisplayChildren(bool $displayChildren = true): static
+    {
+        $this->assertMutable();
+        $this->displayChildren = $displayChildren;
+
+        return $this;
+    }
+
+    public function displaysChildren(): bool
+    {
+        return $this->displayChildren;
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $attributes
+     */
+    public function setLabelAttributes(array $attributes, bool $merge = false): static
+    {
+        $this->assertMutable();
+        $this->labelAttributes = $merge ? $attributes + $this->labelAttributes : $attributes;
+
+        return $this;
+    }
+
+    /**
+     * @phpstan-return array<string, mixed>
+     */
+    public function getLabelAttributes(): array
+    {
+        return $this->labelAttributes;
+    }
+
     public function freeze(): static
     {
         $this->frozen = true;
@@ -504,12 +543,14 @@ class Item implements ItemInterface, StateResetInterface
             'visible' => $this->visible,
             'active' => $this->active,
             'expanded' => $this->expanded,
+            'displayChildren' => $this->displayChildren,
             'before' => $this->before,
             'after' => $this->after,
             'icon' => $this->icon,
             'badge' => $this->badge,
             'badgeType' => $this->badgeType,
             'attributes' => $this->attributes,
+            'labelAttributes' => $this->labelAttributes,
             'data' => $this->data,
             'matchRoutes' => $this->matchRoutes,
             'ignoreQueryString' => $this->ignoreQueryString,

--- a/src/Item/ItemInterface.php
+++ b/src/Item/ItemInterface.php
@@ -131,6 +131,20 @@ interface ItemInterface
 
     public function isExpanded(): bool;
 
+    public function setDisplayChildren(bool $displayChildren = true): static;
+
+    public function displaysChildren(): bool;
+
+    /**
+     * @phpstan-param array<string, mixed> $attributes
+     */
+    public function setLabelAttributes(array $attributes, bool $merge = false): static;
+
+    /**
+     * @phpstan-return array<string, mixed>
+     */
+    public function getLabelAttributes(): array;
+
     public function freeze(): static;
 
     public function isFrozen(): bool;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -91,6 +91,8 @@ class Menu implements MenuInterface
                     'matchRoutes' => $itemConfig['matchRoutes'] ?? [],
                     'ignoreQueryString' => $itemConfig['ignoreQueryString'] ?? null,
                     'fuzzy' => $itemConfig['fuzzy'] ?? false,
+                    'displayChildren' => $itemConfig['displayChildren'] ?? true,
+                    'labelAttributes' => $itemConfig['labelAttributes'] ?? [],
                 ],
             );
 
@@ -326,6 +328,12 @@ class Menu implements MenuInterface
         if (!empty($options['fuzzy'])) {
             $item->setFuzzyMatch();
         }
+        if (array_key_exists('displayChildren', $options)) {
+            $item->setDisplayChildren((bool)$options['displayChildren']);
+        }
+        if (isset($options['labelAttributes']) && is_array($options['labelAttributes'])) {
+            $item->setLabelAttributes($options['labelAttributes']);
+        }
 
         return $item;
     }
@@ -423,6 +431,272 @@ class Menu implements MenuInterface
         $this->items = $items;
 
         return $this;
+    }
+
+    /**
+     * Returns the first item (depth-first) whose key matches. Keys are explicit when set, otherwise
+     * a slug of the label, so labels that collide share a key — assign explicit keys when you need
+     * to target a specific item unambiguously.
+     */
+    public function getByKey(string $key): ?ItemInterface
+    {
+        foreach ($this->items as $item) {
+            if ($item->getKey() === $key) {
+                return $item;
+            }
+            if ($item->hasSubMenu()) {
+                $found = $item->getSubMenu()->getByKey($key);
+                if ($found !== null) {
+                    return $found;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function hasKey(string $key): bool
+    {
+        return $this->getByKey($key) !== null;
+    }
+
+    /**
+     * Removes the first item (depth-first) whose key matches. As with getByKey(), matching uses the
+     * explicit key or the label slug, so prefer explicit keys when labels may collide.
+     */
+    public function removeByKey(string $key): static
+    {
+        $this->assertMutable();
+        $this->removeFirstByKey($key);
+
+        return $this;
+    }
+
+    /**
+     * Removes the first item matching the key, searching this level before descending. Returns
+     * whether an item was removed.
+     */
+    protected function removeFirstByKey(string $key): bool
+    {
+        foreach ($this->items as $index => $item) {
+            if ($item->getKey() === $key) {
+                array_splice($this->items, $index, 1);
+
+                return true;
+            }
+        }
+        foreach ($this->items as $item) {
+            if ($item->hasSubMenu() && $item->getSubMenu()->getByKey($key) !== null) {
+                $item->getSubMenu()->removeByKey($key);
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function insertBefore(ItemInterface $item, string $idOrKey): static
+    {
+        $this->assertMutable();
+        $index = $this->indexOf($idOrKey);
+        if ($index === null) {
+            throw new InvalidArgumentException(sprintf('Unknown menu item `%s` to insert before.', $idOrKey));
+        }
+
+        $this->insertItemAt($item, $index);
+
+        return $this;
+    }
+
+    public function insertAfter(ItemInterface $item, string $idOrKey): static
+    {
+        $this->assertMutable();
+        $index = $this->indexOf($idOrKey);
+        if ($index === null) {
+            throw new InvalidArgumentException(sprintf('Unknown menu item `%s` to insert after.', $idOrKey));
+        }
+
+        $this->insertItemAt($item, $index + 1);
+
+        return $this;
+    }
+
+    public function moveToPosition(string $idOrKey, int $position): static
+    {
+        $this->assertMutable();
+        $index = $this->indexOf($idOrKey);
+        if ($index === null) {
+            throw new InvalidArgumentException(sprintf('Unknown menu item `%s` to move.', $idOrKey));
+        }
+
+        $item = $this->items[$index];
+        array_splice($this->items, $index, 1);
+        $position = max(0, min($position, count($this->items)));
+        array_splice($this->items, $position, 0, [$item]);
+
+        return $this;
+    }
+
+    public function moveToFirstPosition(string $idOrKey): static
+    {
+        return $this->moveToPosition($idOrKey, 0);
+    }
+
+    public function moveToLastPosition(string $idOrKey): static
+    {
+        return $this->moveToPosition($idOrKey, count($this->items));
+    }
+
+    public function reorder(array $order): static
+    {
+        $this->assertMutable();
+        $ordered = [];
+        $used = [];
+        foreach ($order as $idOrKey) {
+            $index = $this->indexOf((string)$idOrKey);
+            if ($index === null || isset($used[$index])) {
+                continue;
+            }
+            $used[$index] = true;
+            $ordered[] = $this->items[$index];
+        }
+        foreach ($this->items as $index => $item) {
+            if (!isset($used[$index])) {
+                $ordered[] = $item;
+            }
+        }
+
+        $this->items = $ordered;
+
+        return $this;
+    }
+
+    public function merge(MenuInterface $menu, bool $mergeAttributes = false): static
+    {
+        $this->assertMutable();
+        foreach ($this->cloneItems($menu->getItems()) as $item) {
+            $this->add($item);
+        }
+
+        if ($mergeAttributes) {
+            $this->attributes += $menu->getAttributes();
+            foreach ((array)$menu->getData() as $name => $value) {
+                if (!array_key_exists((string)$name, $this->data)) {
+                    $this->data[(string)$name] = $value;
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    public function slice(int|string $offset, int|string|null $length = null): static
+    {
+        $start = $this->resolveBoundary($offset);
+        if ($length === null) {
+            $end = count($this->items);
+        } elseif (is_int($length)) {
+            $end = $start + $length;
+        } else {
+            $end = $this->resolveBoundary($length);
+        }
+
+        $slice = array_slice($this->items, $start, max(0, $end - $start));
+
+        $new = static::create($this->attributes);
+        foreach ($this->data as $name => $value) {
+            $new->setData((string)$name, $value);
+        }
+        $new->setItems($this->cloneItems($slice));
+
+        return $new;
+    }
+
+    /**
+     * @phpstan-return array{primary: static, secondary: static}
+     */
+    public function split(int|string $length): array
+    {
+        $boundary = $this->resolveBoundary($length);
+
+        return [
+            'primary' => $this->slice(0, $boundary),
+            'secondary' => $this->slice($boundary),
+        ];
+    }
+
+    /**
+     * Finds the index of a direct child by its id or key, or null when absent. Ids take precedence
+     * so an explicit id can always be targeted, even when another item's slug key collides with it.
+     */
+    protected function indexOf(string $idOrKey): ?int
+    {
+        foreach ($this->items as $index => $item) {
+            if ($item->getId() === $idOrKey) {
+                return $index;
+            }
+        }
+        foreach ($this->items as $index => $item) {
+            if ($item->getKey() === $idOrKey) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves a position argument (an integer index, or an id/key of a direct child) to an index.
+     *
+     * @throws \InvalidArgumentException When a string id/key is not found.
+     */
+    protected function resolveBoundary(int|string $value): int
+    {
+        if (is_int($value)) {
+            return max(0, min($value, count($this->items)));
+        }
+
+        $index = $this->indexOf($value);
+        if ($index === null) {
+            throw new InvalidArgumentException(sprintf('Unknown menu item `%s`.', $value));
+        }
+
+        return $index;
+    }
+
+    protected function insertItemAt(ItemInterface $item, int $position): void
+    {
+        if ($this->ownerItem !== null && !$item->hasParent()) {
+            $item->setParent($this->ownerItem);
+        }
+        $this->assertUniqueItemTree($item);
+        $position = max(0, min($position, count($this->items)));
+        array_splice($this->items, $position, 0, [$item]);
+    }
+
+    /**
+     * Deep-clones a set of items (via array round-trip) so derived menus from slice()/split()/merge()
+     * own independent item objects and leave the source tree untouched.
+     *
+     * Note: cloning goes through toArray()/fromArray(), so items are rebuilt as the base item class;
+     * custom ItemInterface implementations (e.g. SelfRendererInterface) are not preserved in the
+     * derived menu.
+     *
+     * @param list<\Menu\Item\ItemInterface> $items
+     *
+     * @return list<\Menu\Item\ItemInterface>
+     */
+    protected function cloneItems(array $items): array
+    {
+        $config = [
+            'items' => array_map(
+                static fn (ItemInterface $item): array => $item->toArray(),
+                $items,
+            ),
+        ];
+
+        return static::fromArray($config)->getItems();
     }
 
     public function clearActive(): static

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -93,6 +93,36 @@ interface MenuInterface
 
     public function remove(string $id): static;
 
+    public function getByKey(string $key): ?ItemInterface;
+
+    public function hasKey(string $key): bool;
+
+    public function removeByKey(string $key): static;
+
+    public function insertBefore(ItemInterface $item, string $idOrKey): static;
+
+    public function insertAfter(ItemInterface $item, string $idOrKey): static;
+
+    public function moveToPosition(string $idOrKey, int $position): static;
+
+    public function moveToFirstPosition(string $idOrKey): static;
+
+    public function moveToLastPosition(string $idOrKey): static;
+
+    /**
+     * @phpstan-param list<string> $order
+     */
+    public function reorder(array $order): static;
+
+    public function merge(MenuInterface $menu, bool $mergeAttributes = false): static;
+
+    public function slice(int|string $offset, int|string|null $length = null): static;
+
+    /**
+     * @phpstan-return array{primary: static, secondary: static}
+     */
+    public function split(int|string $length): array;
+
     public function clearActive(): static;
 
     public function getActiveItem(): ?ItemInterface;

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -51,6 +51,8 @@ class StringTemplateRenderer implements RendererInterface
         'ariaLabel' => null,
         'addAriaCurrent' => true,
         'addAriaExpanded' => true,
+        // Opt-in WAI-ARIA menu roles (menubar/menu/menuitem/none/separator/presentation).
+        'roles' => false,
         'templates' => [
             'menuWrapper' => '<ul{{attributes}}>{{items}}</ul>',
             'item' => '<li{{attributes}}>{{content}}</li>',
@@ -135,6 +137,10 @@ class StringTemplateRenderer implements RendererInterface
             $attributes = $this->appendClass($attributes, $menuLevelClass . $level);
         }
 
+        if ($this->getBooleanOption($options, 'roles', false) && !isset($attributes['role'])) {
+            $attributes['role'] = $level === 1 ? 'menubar' : 'menu';
+        }
+
         return $this->templater()->format('menuWrapper', [
             'attributes' => $this->renderAttributes($attributes),
             'items' => implode('', $items),
@@ -159,9 +165,14 @@ class StringTemplateRenderer implements RendererInterface
             return $item->render();
         }
 
+        $roles = $this->getBooleanOption($options, 'roles', false);
+
         if ($item->isDivider()) {
             $attributes = $this->applyPositionClasses($item->getAttributes(), $options, $index, $count);
             $attributes = $this->appendConfiguredClass($attributes, $options, 'dividerClass');
+            if ($roles && !isset($attributes['role'])) {
+                $attributes['role'] = 'separator';
+            }
 
             return $this->templater()->format('divider', [
                 'attributes' => $this->renderAttributes($attributes),
@@ -171,6 +182,9 @@ class StringTemplateRenderer implements RendererInterface
         if ($item->isHeader()) {
             $attributes = $this->applyPositionClasses($item->getAttributes(), $options, $index, $count);
             $attributes = $this->appendConfiguredClass($attributes, $options, 'headerClass');
+            if ($roles && !isset($attributes['role'])) {
+                $attributes['role'] = 'presentation';
+            }
 
             return $this->templater()->format('header', [
                 'attributes' => $this->renderAttributes($attributes),
@@ -179,9 +193,9 @@ class StringTemplateRenderer implements RendererInterface
         }
 
         $attributes = $item->getAttributes();
-        $hasSubMenu = $item->hasSubMenu();
+        $renderChildren = $item->hasSubMenu() && $item->displaysChildren();
         if (
-            $hasSubMenu
+            $renderChildren
             && $this->getBooleanOption($options, 'hideEmptyBranches', false)
             && !$this->hasRenderableChild($item, $options)
         ) {
@@ -192,7 +206,7 @@ class StringTemplateRenderer implements RendererInterface
         } elseif ($this->hasActiveDescendant($item)) {
             $attributes = $this->appendConfiguredClass($attributes, $options, 'ancestorClass');
         }
-        if ($hasSubMenu) {
+        if ($renderChildren) {
             $attributes = $this->appendConfiguredClass($attributes, $options, 'branchClass');
             $attributes = $this->appendConfiguredClass($attributes, $options, 'submenuClass');
             if ($this->getBooleanOption($options, 'addAriaExpanded', true)) {
@@ -204,9 +218,12 @@ class StringTemplateRenderer implements RendererInterface
             $attributes = $this->appendConfiguredClass($attributes, $options, 'leafClass');
         }
         $attributes = $this->applyPositionClasses($attributes, $options, $index, $count);
+        if ($roles && !isset($attributes['role'])) {
+            $attributes['role'] = 'none';
+        }
 
         $content = $item->getBefore() . $this->renderContent($item, $options) . $item->getAfter();
-        if ($hasSubMenu) {
+        if ($renderChildren) {
             $content .= $this->renderMenu($item->getSubMenu(), $options, $level + 1);
         }
 
@@ -233,6 +250,8 @@ class StringTemplateRenderer implements RendererInterface
             if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
                 $attributes['aria-current'] = 'page';
             }
+            $attributes = $this->mergeLabelAttributes($attributes, $item);
+            $attributes = $this->applyMenuItemRole($attributes, $item, $options);
 
             return $this->templater()->format('label', [
                 'attributes' => $this->renderAttributes($attributes),
@@ -245,11 +264,61 @@ class StringTemplateRenderer implements RendererInterface
         if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
             $attributes['aria-current'] = 'page';
         }
+        $attributes = $this->mergeLabelAttributes($attributes, $item);
+        $attributes = $this->applyMenuItemRole($attributes, $item, $options);
 
         return $this->templater()->format('link', [
             'attributes' => $this->renderAttributes($attributes),
             'title' => $title,
         ]);
+    }
+
+    /**
+     * Adds the WAI-ARIA `menuitem` role (and `aria-haspopup` for branches) to a link/label when the
+     * `roles` option is enabled.
+     *
+     * @phpstan-param array<string, mixed> $attributes
+     * @phpstan-param array<string, mixed> $options
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    protected function applyMenuItemRole(array $attributes, ItemInterface $item, array $options): array
+    {
+        if (!$this->getBooleanOption($options, 'roles', false)) {
+            return $attributes;
+        }
+        if (!isset($attributes['role'])) {
+            $attributes['role'] = 'menuitem';
+        }
+        if ($item->hasSubMenu() && $item->displaysChildren() && !isset($attributes['aria-haspopup'])) {
+            $attributes['aria-haspopup'] = 'true';
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Merges an item's label attributes onto the rendered link/label element, combining classes.
+     *
+     * @phpstan-param array<string, mixed> $attributes
+     *
+     * @phpstan-return array<string, mixed>
+     */
+    protected function mergeLabelAttributes(array $attributes, ItemInterface $item): array
+    {
+        foreach ($item->getLabelAttributes() as $name => $value) {
+            if ($name === 'class') {
+                $class = is_array($value)
+                    ? implode(' ', array_map('strval', $value))
+                    : (string)$value;
+                $attributes = $this->appendClass($attributes, $class);
+
+                continue;
+            }
+            $attributes[$name] = $value;
+        }
+
+        return $attributes;
     }
 
     protected function escapeLabel(ItemInterface $item): string

--- a/src/Resolver/RegexResolver.php
+++ b/src/Resolver/RegexResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Resolver;
+
+use Menu\Item\ItemInterface;
+use function is_string;
+use function preg_match;
+use function restore_error_handler;
+use function set_error_handler;
+
+/**
+ * Marks items active when the current request path matches a regular expression stored in the item's
+ * data (default key `match`). The value may be a single pattern or a list of patterns; the item is
+ * activated when any pattern matches. Invalid patterns are ignored rather than raising a warning.
+ *
+ * Useful for activating a menu entry across a whole URL section that a route-array match cannot
+ * express, e.g. `'#^/admin/(users|roles)#'`.
+ */
+class RegexResolver implements ResolverInterface
+{
+    use RuntimeStateTrait;
+
+    public function __construct(
+        protected string $path,
+        protected string $dataKey = 'match',
+    ) {
+    }
+
+    public function resolve(ItemInterface $item): void
+    {
+        $patterns = $item->getData($this->dataKey);
+        if ($patterns === null) {
+            return;
+        }
+
+        foreach ((array)$patterns as $pattern) {
+            if (!is_string($pattern) || $pattern === '') {
+                continue;
+            }
+            if ($this->matches($pattern)) {
+                $this->applyActive($item);
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * Tests a pattern against the request path, swallowing the warning an invalid pattern emits so a
+     * bad entry never breaks rendering.
+     */
+    protected function matches(string $pattern): bool
+    {
+        set_error_handler(static fn (): bool => true);
+        try {
+            return preg_match($pattern, $this->path) === 1;
+        } finally {
+            restore_error_handler();
+        }
+    }
+}

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Menu\View\Helper;
 
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Cake\View\Helper;
 use Closure;
 use InvalidArgumentException;
@@ -42,6 +44,22 @@ class MenuHelper extends Helper
      */
     protected array $menuConfigs = [];
 
+    /**
+     * Specs from `Configure::read('Menu.menus')`, materialized lazily on first access so an explicit
+     * create()/register() of the same name takes precedence.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $configuredMenus = [];
+
+    /**
+     * Names currently materialized from `configuredMenus` (not explicitly created/registered), so an
+     * explicit create()/register() of the same name can still override them after first access.
+     *
+     * @var array<string, true>
+     */
+    protected array $configOrigin = [];
+
     protected ?string $lastMenuName = null;
 
     protected array $_defaultConfig = [
@@ -52,6 +70,36 @@ class MenuHelper extends Helper
         'currentAsLink' => true,
         'resolveDepth' => null,
     ];
+
+    /**
+     * @phpstan-param array<string, mixed> $config
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+        $this->loadConfiguredMenus();
+    }
+
+    /**
+     * Stores menu specs declared in `Configure::read('Menu.menus')` (each value a `Menu::fromArray()`
+     * spec keyed by menu name) so config-defined menus are renderable without wiring. They are
+     * materialized lazily by get(); an explicit create()/register() of the same name overrides the
+     * configured menu entirely.
+     */
+    protected function loadConfiguredMenus(): void
+    {
+        $menus = Configure::read('Menu.menus');
+        if (!is_array($menus)) {
+            return;
+        }
+
+        foreach ($menus as $name => $spec) {
+            if (!is_string($name) || $name === '' || !is_array($spec)) {
+                continue;
+            }
+            $this->configuredMenus[$name] = $spec;
+        }
+    }
 
     /**
      * @phpstan-param array<string, mixed> $options
@@ -78,13 +126,16 @@ class MenuHelper extends Helper
         $this->menus[$name] = $menu;
         $this->menuConfigs[$name] = $options;
         $this->lastMenuName = $name;
+        // Now explicitly defined in code; drop any config-origin marker so it is no longer
+        // re-materialized from configuration.
+        unset($this->configOrigin[$name]);
 
         return $menu;
     }
 
     public function has(string $name): bool
     {
-        return isset($this->menus[$name]);
+        return isset($this->menus[$name]) || isset($this->configuredMenus[$name]);
     }
 
     /**
@@ -106,28 +157,98 @@ class MenuHelper extends Helper
      */
     public function register(string $name, callable $callback, array $options = []): MenuInterface
     {
-        if ($this->has($name) && empty($options['rebuild'])) {
+        if (isset($options['cache']) && $options['cache'] !== false) {
+            return $this->registerWithCache($name, $callback, $options);
+        }
+
+        if (isset($this->menus[$name]) && !isset($this->configOrigin[$name]) && empty($options['rebuild'])) {
             return $this->get($name);
         }
 
-        if (!empty($options['rebuild'])) {
-            $options['overwrite'] = true;
-            $menu = $this->create($name, $options);
-
-            $this->invokeRegisterCallback($callback, $menu);
-
-            return $menu;
-        }
-
-        $menu = $this->getOrCreate($name, $options);
+        // An explicit registration defines the menu in code, overriding any configured menu of the
+        // same name. Configured menus are only used when a name is not registered/created in code.
+        $options['overwrite'] = true;
+        $menu = $this->create($name, $options);
         $this->invokeRegisterCallback($callback, $menu);
 
         return $menu;
     }
 
+    /**
+     * Builds a menu through the callback once and caches its structure (not its active state), so
+     * later requests skip the (potentially expensive) build and load the tree from cache instead.
+     * Active state is always resolved fresh per request at render time. Pass `rebuild => true` to
+     * force a rebuild and refresh the cache. The cached structure is the serialized array form, so
+     * custom item classes are restored as the base item class — cache data-driven menus, not menus
+     * relying on custom ItemInterface implementations.
+     *
+     * @param string $name
+     * @param callable(\Menu\MenuInterface): void|callable(\Menu\MenuInterface, self): void $callback
+     * @param array<string, mixed> $options
+     */
+    protected function registerWithCache(string $name, callable $callback, array $options): MenuInterface
+    {
+        if (isset($this->menus[$name]) && !isset($this->configOrigin[$name]) && empty($options['rebuild'])) {
+            return $this->get($name);
+        }
+
+        [$cacheKey, $cacheConfig] = $this->resolveCacheTarget($options['cache'], $name);
+
+        if (empty($options['rebuild'])) {
+            $cached = Cache::read($cacheKey, $cacheConfig);
+            if (is_array($cached)) {
+                $menu = Menu::fromArray($cached);
+                $this->menus[$name] = $menu;
+                $this->menuConfigs[$name] = $options;
+                $this->lastMenuName = $name;
+                // Now defined in code (from cache); drop any config-origin marker.
+                unset($this->configOrigin[$name]);
+
+                return $menu;
+            }
+        }
+
+        $options['overwrite'] = true;
+        $menu = $this->create($name, $options);
+        $this->invokeRegisterCallback($callback, $menu);
+        Cache::write($cacheKey, $menu->toArray(), $cacheConfig);
+
+        return $menu;
+    }
+
+    /**
+     * Normalizes the `cache` option into a [key, config] pair. Accepts `true` (cache under the menu
+     * name in the `default` config), a string key (in the `default` config), or
+     * `['key' => ..., 'config' => ...]`. When no key is given, the menu name is used so distinct
+     * menus never share a cache entry.
+     *
+     * @return array{0: string, 1: string}
+     */
+    protected function resolveCacheTarget(mixed $cache, string $name): array
+    {
+        if (is_array($cache)) {
+            return [
+                (string)($cache['key'] ?? $name),
+                (string)($cache['config'] ?? 'default'),
+            ];
+        }
+
+        if (is_string($cache) && $cache !== '') {
+            return [$cache, 'default'];
+        }
+
+        // e.g. `cache => true`: cache under the menu name so menus never collide.
+        return [$name, 'default'];
+    }
+
     public function remove(string $name): static
     {
-        unset($this->menus[$name], $this->menuConfigs[$name]);
+        unset(
+            $this->menus[$name],
+            $this->menuConfigs[$name],
+            $this->configuredMenus[$name],
+            $this->configOrigin[$name],
+        );
         if ($this->lastMenuName === $name) {
             $this->lastMenuName = null;
         }
@@ -139,7 +260,11 @@ class MenuHelper extends Helper
     {
         $this->menus = [];
         $this->menuConfigs = [];
+        $this->configuredMenus = [];
+        $this->configOrigin = [];
         $this->lastMenuName = null;
+        // Restore configured menus to their pristine state so they remain available after a reset.
+        $this->loadConfiguredMenus();
 
         return $this;
     }
@@ -149,11 +274,21 @@ class MenuHelper extends Helper
      */
     public function get(string $name): MenuInterface
     {
-        if (!isset($this->menus[$name])) {
-            throw new InvalidArgumentException(sprintf('Unknown menu `%s`.', $name));
+        if (isset($this->menus[$name])) {
+            return $this->menus[$name];
         }
 
-        return $this->menus[$name];
+        if (isset($this->configuredMenus[$name])) {
+            $menu = Menu::fromArray($this->configuredMenus[$name]);
+            $this->menus[$name] = $menu;
+            $this->menuConfigs[$name] = [];
+            $this->configOrigin[$name] = true;
+            $this->lastMenuName ??= $name;
+
+            return $menu;
+        }
+
+        throw new InvalidArgumentException(sprintf('Unknown menu `%s`.', $name));
     }
 
     /**

--- a/tests/TestCase/Item/ItemFeaturesTest.php
+++ b/tests/TestCase/Item/ItemFeaturesTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Item;
+
+use Cake\TestSuite\TestCase;
+use Menu\Item\Item;
+use Menu\Menu;
+
+class ItemFeaturesTest extends TestCase
+{
+    public function testDisplayChildrenDefaultsTrue(): void
+    {
+        $item = new Item('Parent', '/parent');
+
+        $this->assertTrue($item->displaysChildren());
+        $this->assertTrue($item->toArray()['displayChildren']);
+    }
+
+    public function testSetDisplayChildren(): void
+    {
+        $item = (new Item('Parent', '/parent'))->setDisplayChildren(false);
+
+        $this->assertFalse($item->displaysChildren());
+        $this->assertFalse($item->toArray()['displayChildren']);
+    }
+
+    public function testLabelAttributes(): void
+    {
+        $item = (new Item('Home', '/home'))
+            ->setLabelAttributes(['title' => 'Go home', 'class' => 'lbl']);
+
+        $this->assertSame(['title' => 'Go home', 'class' => 'lbl'], $item->getLabelAttributes());
+        $this->assertSame(['title' => 'Go home', 'class' => 'lbl'], $item->toArray()['labelAttributes']);
+    }
+
+    public function testLabelAttributesMerge(): void
+    {
+        $item = (new Item('Home', '/home'))
+            ->setLabelAttributes(['title' => 'A'])
+            ->setLabelAttributes(['data-x' => '1'], true);
+
+        $this->assertSame(['data-x' => '1', 'title' => 'A'], $item->getLabelAttributes());
+    }
+
+    public function testNewItemOptions(): void
+    {
+        $menu = Menu::create();
+        $item = $menu->addItem('X', '/x', [
+            'displayChildren' => false,
+            'labelAttributes' => ['title' => 'tip'],
+        ]);
+
+        $this->assertFalse($item->displaysChildren());
+        $this->assertSame(['title' => 'tip'], $item->getLabelAttributes());
+    }
+
+    public function testFromArrayRoundTrip(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Parent', '/parent', [
+            'key' => 'parent',
+            'displayChildren' => false,
+            'labelAttributes' => ['title' => 'tip'],
+        ]);
+
+        $rebuilt = Menu::fromArray($menu->toArray());
+        $item = $rebuilt->getByKey('parent');
+
+        $this->assertNotNull($item);
+        $this->assertFalse($item->displaysChildren());
+        $this->assertSame(['title' => 'tip'], $item->getLabelAttributes());
+    }
+}

--- a/tests/TestCase/Menu/MenuManipulationTest.php
+++ b/tests/TestCase/Menu/MenuManipulationTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Menu;
+
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use LogicException;
+use Menu\Menu;
+
+class MenuManipulationTest extends TestCase
+{
+    /**
+     * @param \Menu\MenuInterface $menu
+     *
+     * @return list<string>
+     */
+    protected function keys($menu): array
+    {
+        return array_map(static fn ($item): string => $item->getKey(), $menu->getItems());
+    }
+
+    public function testGetByKeyExplicitAndSlug(): void
+    {
+        $menu = Menu::create();
+        $dashboard = $menu->addItem('Dashboard', '/d');
+        $profile = $menu->addItem('Profile', '/p', ['key' => 'profile']);
+
+        $this->assertSame($profile, $menu->getByKey('profile'));
+        $this->assertSame($dashboard, $menu->getByKey('dashboard'));
+        $this->assertNull($menu->getByKey('missing'));
+    }
+
+    public function testGetByKeyRecursive(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '#');
+        $child = $parent->getSubMenu()->addItem('Child', '/c', ['key' => 'child']);
+
+        $this->assertSame($child, $menu->getByKey('child'));
+        $this->assertTrue($menu->hasKey('child'));
+        $this->assertFalse($menu->hasKey('nope'));
+    }
+
+    public function testRemoveByKey(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Keep', '/k', ['key' => 'keep']);
+        $menu->addItem('Drop', '/d', ['key' => 'drop']);
+
+        $menu->removeByKey('drop');
+
+        $this->assertNull($menu->getByKey('drop'));
+        $this->assertSame(['keep'], $this->keys($menu));
+    }
+
+    public function testRemoveByKeyRemovesOnlyFirstMatch(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Settings', '/a'); // implicit slug key "settings"
+        $menu->addItem('Settings', '/b'); // same slug key
+        $menu->addItem('Other', '/c');
+
+        $menu->removeByKey('settings');
+
+        $this->assertSame(['settings', 'other'], $this->keys($menu));
+        $this->assertSame('/b', $menu->getItems()[0]->getLink()?->getRawUrl());
+    }
+
+    public function testRemoveByKeyRecursesIntoSubmenu(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '#');
+        $parent->getSubMenu()->addItem('Child', '/c', ['key' => 'child']);
+        $parent->getSubMenu()->addItem('Keep', '/k', ['key' => 'keep']);
+
+        $menu->removeByKey('child');
+
+        $this->assertNull($menu->getByKey('child'));
+        $this->assertNotNull($menu->getByKey('keep'));
+    }
+
+    public function testIndexResolutionPrefersIdOverCollidingKey(): void
+    {
+        $menu = Menu::create();
+        // Item labeled "Settings" gets the implicit slug key "settings".
+        $menu->addItem('Settings', '/settings');
+        // A later item explicitly uses the id "settings".
+        $menu->addItem('Other', '/other', ['id' => 'settings']);
+
+        $menu->moveToFirstPosition('settings');
+
+        // The explicit id wins, so "Other" moves first rather than the slug-keyed item.
+        $this->assertSame('Other', $menu->getItems()[0]->getLabel());
+    }
+
+    public function testInsertBefore(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('A', '/a', ['key' => 'a']);
+        $menu->addItem('C', '/c', ['key' => 'c']);
+
+        $b = $menu->newItem('B', '/b', ['key' => 'b']);
+        $menu->insertBefore($b, 'c');
+
+        $this->assertSame(['a', 'b', 'c'], $this->keys($menu));
+    }
+
+    public function testInsertAfter(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('A', '/a', ['key' => 'a']);
+        $menu->addItem('C', '/c', ['key' => 'c']);
+
+        $b = $menu->newItem('B', '/b', ['key' => 'b']);
+        $menu->insertAfter($b, 'a');
+
+        $this->assertSame(['a', 'b', 'c'], $this->keys($menu));
+    }
+
+    public function testInsertBeforeUnknownReferenceThrows(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('A', '/a', ['key' => 'a']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $menu->insertBefore($menu->newItem('B', '/b'), 'missing');
+    }
+
+    public function testMoveToPosition(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('A', '/a', ['key' => 'a']);
+        $menu->addItem('B', '/b', ['key' => 'b']);
+        $menu->addItem('C', '/c', ['key' => 'c']);
+
+        $menu->moveToPosition('c', 0);
+
+        $this->assertSame(['c', 'a', 'b'], $this->keys($menu));
+    }
+
+    public function testMoveToFirstAndLastPosition(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('A', '/a', ['key' => 'a']);
+        $menu->addItem('B', '/b', ['key' => 'b']);
+        $menu->addItem('C', '/c', ['key' => 'c']);
+
+        $menu->moveToLastPosition('a');
+        $this->assertSame(['b', 'c', 'a'], $this->keys($menu));
+
+        $menu->moveToFirstPosition('c');
+        $this->assertSame(['c', 'b', 'a'], $this->keys($menu));
+    }
+
+    public function testReorderAppendsUnlisted(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('A', '/a', ['key' => 'a']);
+        $menu->addItem('B', '/b', ['key' => 'b']);
+        $menu->addItem('C', '/c', ['key' => 'c']);
+
+        $menu->reorder(['c', 'a']);
+
+        $this->assertSame(['c', 'a', 'b'], $this->keys($menu));
+    }
+
+    public function testMergeClonesAndLeavesSourceIntact(): void
+    {
+        $main = Menu::create();
+        $main->addItem('A', '/a', ['key' => 'a']);
+        $main->addItem('B', '/b', ['key' => 'b']);
+
+        $other = Menu::create();
+        $other->addItem('C', '/c', ['key' => 'c']);
+        $other->addItem('D', '/d', ['key' => 'd']);
+
+        $main->merge($other);
+
+        $this->assertSame(['a', 'b', 'c', 'd'], $this->keys($main));
+        $this->assertSame(['c', 'd'], $this->keys($other));
+    }
+
+    public function testMergeAttributes(): void
+    {
+        $main = Menu::create(['class' => 'nav']);
+        $other = Menu::create(['id' => 'main', 'class' => 'ignored']);
+
+        $main->merge($other, true);
+
+        $this->assertSame(['class' => 'nav', 'id' => 'main'], $main->getAttributes());
+    }
+
+    public function testSliceByIndex(): void
+    {
+        $menu = Menu::create(['class' => 'nav']);
+        foreach (['a', 'b', 'c', 'd'] as $key) {
+            $menu->addItem(strtoupper($key), '/' . $key, ['key' => $key]);
+        }
+
+        $slice = $menu->slice(1, 2);
+
+        $this->assertNotSame($menu, $slice);
+        $this->assertSame(['b', 'c'], $this->keys($slice));
+        $this->assertSame(['class' => 'nav'], $slice->getAttributes());
+        // Original untouched.
+        $this->assertSame(['a', 'b', 'c', 'd'], $this->keys($menu));
+    }
+
+    public function testSliceByKeyBoundaries(): void
+    {
+        $menu = Menu::create();
+        foreach (['a', 'b', 'c', 'd'] as $key) {
+            $menu->addItem(strtoupper($key), '/' . $key, ['key' => $key]);
+        }
+
+        $slice = $menu->slice('b', 'd');
+
+        $this->assertSame(['b', 'c'], $this->keys($slice));
+    }
+
+    public function testSplit(): void
+    {
+        $menu = Menu::create();
+        foreach (['a', 'b', 'c', 'd'] as $key) {
+            $menu->addItem(strtoupper($key), '/' . $key, ['key' => $key]);
+        }
+
+        $parts = $menu->split(2);
+
+        $this->assertSame(['a', 'b'], $this->keys($parts['primary']));
+        $this->assertSame(['c', 'd'], $this->keys($parts['secondary']));
+    }
+
+    public function testFrozenMenuRejectsManipulation(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('A', '/a', ['key' => 'a']);
+        $menu->freeze();
+
+        $this->expectException(LogicException::class);
+        $menu->moveToFirstPosition('a');
+    }
+}

--- a/tests/TestCase/Renderer/RendererFeaturesTest.php
+++ b/tests/TestCase/Renderer/RendererFeaturesTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Renderer;
+
+use Cake\TestSuite\TestCase;
+use Menu\Menu;
+use Menu\Renderer\StringTemplateRenderer;
+
+class RendererFeaturesTest extends TestCase
+{
+    public function testDisplayChildrenFalseSuppressesSubmenu(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '/parent');
+        $parent->getSubMenu()->addItem('Child', '/child');
+        $parent->setDisplayChildren(false);
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertSame(
+            '<ul><li><a href="/parent">Parent</a></li></ul>',
+            $result,
+        );
+    }
+
+    public function testDisplayChildrenTrueRendersSubmenu(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '/parent');
+        $parent->getSubMenu()->addItem('Child', '/child');
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertSame(
+            '<ul><li class="has-children" aria-expanded="false"><a href="/parent">Parent</a>'
+            . '<ul class="submenu"><li><a href="/child">Child</a></li></ul></li></ul>',
+            $result,
+        );
+    }
+
+    public function testLabelAttributesOnLink(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home')->setLabelAttributes(['title' => 'Go home', 'class' => 'lbl']);
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertSame(
+            '<ul><li><a href="/home" title="Go home" class="lbl">Home</a></li></ul>',
+            $result,
+        );
+    }
+
+    public function testLabelAttributesOnActiveLabel(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home', ['active' => true])->setLabelAttributes(['title' => 'Here']);
+
+        $result = (new StringTemplateRenderer(['currentAsLink' => false]))->render($menu);
+
+        $this->assertSame(
+            '<ul><li class="active"><span aria-current="page" title="Here">Home</span></li></ul>',
+            $result,
+        );
+    }
+
+    public function testAriaRolesOffByDefault(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home');
+
+        $result = (new StringTemplateRenderer())->render($menu);
+
+        $this->assertStringNotContainsString('role=', $result);
+    }
+
+    public function testAriaRolesOnNestedMenu(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '/parent');
+        $parent->getSubMenu()->addItem('Child', '/child');
+
+        $result = (new StringTemplateRenderer())->render($menu, ['roles' => true]);
+
+        $this->assertSame(
+            '<ul role="menubar">'
+            . '<li class="has-children" aria-expanded="false" role="none">'
+            . '<a href="/parent" role="menuitem" aria-haspopup="true">Parent</a>'
+            . '<ul class="submenu" role="menu">'
+            . '<li role="none"><a href="/child" role="menuitem">Child</a></li>'
+            . '</ul></li></ul>',
+            $result,
+        );
+    }
+
+    public function testAriaRolesDividerAndHeader(): void
+    {
+        $menu = Menu::create();
+        $menu->addHeader('Section');
+        $menu->addDivider();
+
+        $result = (new StringTemplateRenderer())->render($menu, ['roles' => true]);
+
+        $this->assertStringContainsString('<li class="menu-header" role="presentation">Section</li>', $result);
+        $this->assertStringContainsString('<li class="divider" role="separator"></li>', $result);
+    }
+}

--- a/tests/TestCase/Resolver/RegexResolverTest.php
+++ b/tests/TestCase/Resolver/RegexResolverTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\Resolver;
+
+use Cake\TestSuite\TestCase;
+use Menu\Item\Item;
+use Menu\Resolver\RegexResolver;
+
+class RegexResolverTest extends TestCase
+{
+    public function testMatchesPattern(): void
+    {
+        $item = (new Item('Articles', '/articles'))->setData('match', '#^/articles#');
+
+        (new RegexResolver('/articles/view/42'))->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testDoesNotMatch(): void
+    {
+        $item = (new Item('Users', '/users'))->setData('match', '#^/users#');
+
+        (new RegexResolver('/articles'))->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testMatchesAnyOfMultiplePatterns(): void
+    {
+        $item = (new Item('Content'))->setData('match', ['#^/articles#', '#^/pages#']);
+
+        (new RegexResolver('/pages/about'))->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testNoDataLeavesItemUntouched(): void
+    {
+        $item = new Item('Home', '/');
+
+        (new RegexResolver('/'))->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function testCustomDataKey(): void
+    {
+        $item = (new Item('X'))->setData('activePattern', '#^/x#');
+
+        (new RegexResolver('/x/y', 'activePattern'))->resolve($item);
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function testInvalidPatternIsIgnored(): void
+    {
+        $item = (new Item('X'))->setData('match', 'not-a-valid-regex(');
+
+        (new RegexResolver('/x'))->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+}

--- a/tests/TestCase/View/Helper/MenuHelperCacheConfigTest.php
+++ b/tests/TestCase/View/Helper/MenuHelperCacheConfigTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Menu\Test\TestCase\View\Helper;
+
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+use Cake\Http\Response;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use InvalidArgumentException;
+use Menu\MenuInterface;
+use Menu\View\Helper\MenuHelper;
+
+class MenuHelperCacheConfigTest extends TestCase
+{
+    protected function createHelper(ServerRequest $request): MenuHelper
+    {
+        return new MenuHelper(new View(
+            request: $request,
+            response: new Response(),
+        ));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::setConfig('menu_test', ['className' => 'Array']);
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::clear('menu_test');
+        Cache::drop('menu_test');
+        Configure::delete('Menu.menus');
+        parent::tearDown();
+    }
+
+    public function testRegisterWithCacheBuildsOnceThenReadsFromCache(): void
+    {
+        $calls = 0;
+        $build = function (MenuInterface $menu) use (&$calls): void {
+            $calls++;
+            $menu->addItem('Home', '/home');
+        };
+        $options = ['cache' => ['key' => 'menu_main', 'config' => 'menu_test']];
+
+        $this->createHelper(new ServerRequest())->register('main', $build, $options);
+        $this->assertSame(1, $calls);
+
+        // A fresh helper (simulating another request) loads from cache without rebuilding.
+        $helper = $this->createHelper(new ServerRequest());
+        $helper->register('main', $build, $options);
+
+        $this->assertSame(1, $calls);
+        $this->assertSame(
+            '<ul><li><a href="/home">Home</a></li></ul>',
+            $helper->render('main'),
+        );
+    }
+
+    public function testCacheKeyDefaultsToMenuNameSoMenusDoNotCollide(): void
+    {
+        $options = ['cache' => ['config' => 'menu_test']]; // no explicit key
+
+        $first = $this->createHelper(new ServerRequest());
+        $first->register('alpha', static function (MenuInterface $m): void {
+            $m->addItem('Alpha', '/alpha');
+        }, $options);
+        $first->register('beta', static function (MenuInterface $m): void {
+            $m->addItem('Beta', '/beta');
+        }, $options);
+
+        // A fresh helper reads each menu from its own cache entry (keyed by menu name).
+        $second = $this->createHelper(new ServerRequest());
+        $second->register('alpha', static function (MenuInterface $m): void {
+            $m->addItem('X', '/x');
+        }, $options);
+        $second->register('beta', static function (MenuInterface $m): void {
+            $m->addItem('Y', '/y');
+        }, $options);
+
+        $this->assertSame('<ul><li><a href="/alpha">Alpha</a></li></ul>', $second->render('alpha'));
+        $this->assertSame('<ul><li><a href="/beta">Beta</a></li></ul>', $second->render('beta'));
+    }
+
+    public function testBooleanCacheUsesMenuNameAsKey(): void
+    {
+        Cache::setConfig('default', ['className' => 'Array']);
+        try {
+            $first = $this->createHelper(new ServerRequest());
+            $first->register('alpha', static function (MenuInterface $m): void {
+                $m->addItem('Alpha', '/alpha');
+            }, ['cache' => true]);
+            $first->register('beta', static function (MenuInterface $m): void {
+                $m->addItem('Beta', '/beta');
+            }, ['cache' => true]);
+
+            $second = $this->createHelper(new ServerRequest());
+            $second->register('alpha', static function (MenuInterface $m): void {
+                $m->addItem('X', '/x');
+            }, ['cache' => true]);
+            $second->register('beta', static function (MenuInterface $m): void {
+                $m->addItem('Y', '/y');
+            }, ['cache' => true]);
+
+            $this->assertSame('<ul><li><a href="/alpha">Alpha</a></li></ul>', $second->render('alpha'));
+            $this->assertSame('<ul><li><a href="/beta">Beta</a></li></ul>', $second->render('beta'));
+        } finally {
+            Cache::clear('default');
+            Cache::drop('default');
+        }
+    }
+
+    public function testRegisterWithCacheRebuildForcesRebuild(): void
+    {
+        $calls = 0;
+        $build = function (MenuInterface $menu) use (&$calls): void {
+            $calls++;
+            $menu->addItem('Home', '/home');
+        };
+        $options = ['cache' => ['key' => 'menu_main', 'config' => 'menu_test']];
+
+        $this->createHelper(new ServerRequest())->register('main', $build, $options);
+        $this->createHelper(new ServerRequest())->register('main', $build, $options + ['rebuild' => true]);
+
+        $this->assertSame(2, $calls);
+    }
+
+    public function testAutoLoadsMenusFromConfigure(): void
+    {
+        Configure::write('Menu.menus', [
+            'main' => [
+                'attributes' => ['class' => 'nav'],
+                'items' => [
+                    ['label' => 'Home', 'link' => '/home'],
+                ],
+            ],
+        ]);
+
+        $helper = $this->createHelper(new ServerRequest());
+
+        $this->assertTrue($helper->has('main'));
+        $this->assertSame(
+            '<ul class="nav"><li><a href="/home">Home</a></li></ul>',
+            $helper->render('main'),
+        );
+    }
+
+    public function testRegisterOverridesConfiguredMenu(): void
+    {
+        Configure::write('Menu.menus', [
+            'main' => ['items' => [['label' => 'Home', 'link' => '/home']]],
+        ]);
+
+        $helper = $this->createHelper(new ServerRequest());
+        $helper->register('main', function (MenuInterface $menu): void {
+            $menu->addItem('Extra', '/extra');
+        });
+
+        // An explicit registration runs its callback and overrides the configured menu of the same
+        // name (the callback is never silently dropped).
+        $this->assertSame(
+            '<ul><li><a href="/extra">Extra</a></li></ul>',
+            $helper->render('main'),
+        );
+    }
+
+    public function testRegisterOverridesConfiguredMenuEvenAfterRender(): void
+    {
+        Configure::write('Menu.menus', [
+            'main' => ['items' => [['label' => 'Home', 'link' => '/home']]],
+        ]);
+
+        $helper = $this->createHelper(new ServerRequest());
+        // Materialize the configured menu first (inspect/render), then register over it.
+        $helper->render('main');
+        $helper->register('main', function (MenuInterface $menu): void {
+            $menu->addItem('Extra', '/extra');
+        });
+
+        $this->assertSame(
+            '<ul><li><a href="/extra">Extra</a></li></ul>',
+            $helper->render('main'),
+        );
+    }
+
+    public function testRemoveDeletesConfiguredMenu(): void
+    {
+        Configure::write('Menu.menus', [
+            'main' => ['items' => [['label' => 'Home', 'link' => '/home']]],
+        ]);
+
+        $helper = $this->createHelper(new ServerRequest());
+        $helper->render('main');
+        $helper->remove('main');
+
+        $this->assertFalse($helper->has('main'));
+        $this->expectException(InvalidArgumentException::class);
+        $helper->render('main');
+    }
+
+    public function testResetKeepsConfiguredMenusAvailable(): void
+    {
+        Configure::write('Menu.menus', [
+            'main' => ['items' => [['label' => 'Home', 'link' => '/home']]],
+        ]);
+
+        $helper = $this->createHelper(new ServerRequest());
+        $helper->render('main');
+        $helper->reset();
+
+        // Configured menus remain available after a reset (config is still present).
+        $this->assertTrue($helper->has('main'));
+        $this->assertSame(
+            '<ul><li><a href="/home">Home</a></li></ul>',
+            $helper->render('main'),
+        );
+    }
+}


### PR DESCRIPTION
Closes several functional gaps relative to KnpMenu / icings/menu, plus two ergonomic infrastructure additions. All on the public interfaces (the plugin is unreleased, 0.x-dev).

## Menu API parity

- **Tree manipulation** on `Menu`: `insertBefore` / `insertAfter`, `moveToPosition` / `moveToFirstPosition` / `moveToLastPosition`, `reorder`, `merge`, and `slice` / `split`. Derived menus (`slice`/`split`/`merge`) copy items, leaving the source tree intact.
- **Key-based lookup/removal**: `getByKey` / `hasKey` / `removeByKey` (explicit key or label slug; first match). Ids take precedence when resolving an id/key target.
- **Per-item `displayChildren`** — render an item without its submenu (treated as a leaf).
- **`labelAttributes`** — attributes applied to the rendered link/label element (classes merge).
- **`RegexResolver`** — activates items whose regular expression (item data `match`) matches the request path; supports a list of patterns and ignores invalid ones.

## Infrastructure

- **Built-in caching** — a `register()` `cache` option builds the menu once and caches its *structure*; active state is always resolved fresh per request. Accepts `true`, a string key, or `['key' => ..., 'config' => ...]` (key defaults to the menu name). Custom item classes are restored as the base item class (documented).
- **Config-defined menus** — the helper auto-registers specs from `Configure::read('Menu.menus')`, so config menus render with no wiring. An explicit `create()`/`register()` of the same name overrides the configured menu; configured menus are materialized lazily, overridable after first access, and removable.

## Accessibility

- Opt-in **WAI-ARIA menu roles** via a renderer `roles` option (`menubar`/`menu`/`menuitem`/`none`/`separator`/`presentation`, plus `aria-haspopup` on branches). Off by default, so existing markup is unchanged.

## Docs

Guide (building, resolvers, rendering, recipes) and the reference pages are updated in this PR, and `config/app.example.php` documents the new `Menu.menus` config key.
