### PR TITLE
Apply labelAttributes and roles options in Bootstrap5/Sidebar/Navbar renderers

### DIFF
--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -54,6 +54,8 @@ class Bootstrap5Renderer extends StringTemplateRenderer
             if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
                 $attributes['aria-current'] = 'page';
             }
+            $attributes = $this->mergeLabelAttributes($attributes, $item);
+            $attributes = $this->applyMenuItemRole($attributes, $item, $options);
 
             return $this->templater()->format('label', [
                 'attributes' => $this->renderAttributes($attributes),
@@ -81,6 +83,8 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
             $attributes['aria-current'] = 'page';
         }
+        $attributes = $this->mergeLabelAttributes($attributes, $item);
+        $attributes = $this->applyMenuItemRole($attributes, $item, $options);
 
         return $this->templater()->format('link', [
             'attributes' => $this->renderAttributes($attributes),

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -188,11 +188,15 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
 
         if ($asLabel) {
             unset($attributes['href']);
+            $attributes = $this->mergeLabelAttributes($attributes, $item);
+            $attributes = $this->applyMenuItemRole($attributes, $item, $options);
 
             return sprintf('<span%s>%s</span>', $this->renderAttributes($attributes), $label);
         }
 
         $attributes['href'] = $link->getUrl() ?? '#';
+        $attributes = $this->mergeLabelAttributes($attributes, $item);
+        $attributes = $this->applyMenuItemRole($attributes, $item, $options);
 
         return sprintf('<a%s>%s</a>', $this->renderAttributes($attributes), $label);
     }
@@ -210,7 +214,7 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
 
         $head = $hasRealUrl
             ? $this->renderNavigableBranch($item, $options, $label, $id, $url, $expanded)
-            : $this->renderToggle($options, $label, $id, $expanded);
+            : $this->renderToggle($item, $options, $label, $id, $expanded);
 
         $collapse = sprintf(
             '<div%s>%s</div>',
@@ -232,7 +236,7 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
      *
      * @phpstan-param array<string, mixed> $options
      */
-    protected function renderToggle(array $options, string $label, string $id, bool $expanded): string
+    protected function renderToggle(ItemInterface $item, array $options, string $label, string $id, bool $expanded): string
     {
         $classes = [$this->getStringOption($options, 'toggleClass')];
         if ($expanded) {
@@ -250,6 +254,8 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
             'aria-controls' => $id,
             'aria-expanded' => $expanded ? 'true' : 'false',
         ];
+        $attributes = $this->mergeLabelAttributes($attributes, $item);
+        $attributes = $this->applyMenuItemRole($attributes, $item, $options);
 
         return sprintf(
             '<a%s>%s%s</a>',
@@ -284,6 +290,10 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
         if ($item->isActive() && $this->getBooleanOption($options, 'addAriaCurrent', true)) {
             $linkAttributes['aria-current'] = 'page';
         }
+        // labelAttributes describe the rendered link/label; merge onto the navigable anchor only,
+        // not the separate toggle button (which is renderer chrome, not the item's link).
+        $linkAttributes = $this->mergeLabelAttributes($linkAttributes, $item);
+        $linkAttributes = $this->applyMenuItemRole($linkAttributes, $item, $options);
 
         $anchor = sprintf('<a%s>%s</a>', $this->renderAttributes($linkAttributes), $label);
 

--- a/tests/TestCase/Renderer/RendererFeaturesTest.php
+++ b/tests/TestCase/Renderer/RendererFeaturesTest.php
@@ -6,6 +6,9 @@ namespace Menu\Test\TestCase\Renderer;
 
 use Cake\TestSuite\TestCase;
 use Menu\Menu;
+use Menu\Renderer\Bootstrap5Renderer;
+use Menu\Renderer\Bootstrap5SidebarRenderer;
+use Menu\Renderer\NavbarRenderer;
 use Menu\Renderer\StringTemplateRenderer;
 
 class RendererFeaturesTest extends TestCase
@@ -105,5 +108,101 @@ class RendererFeaturesTest extends TestCase
 
         $this->assertStringContainsString('<li class="menu-header" role="presentation">Section</li>', $result);
         $this->assertStringContainsString('<li class="divider" role="separator"></li>', $result);
+    }
+
+    // ---------------------------------------------------------------------
+    // labelAttributes / roles parity across renderers. Previously these were
+    // honored only by StringTemplateRenderer; the Bootstrap5-family renderers
+    // override the link/label rendering path and silently dropped them.
+    // ---------------------------------------------------------------------
+
+    public function testLabelAttributesOnBootstrap5Link(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home')->setLabelAttributes(['title' => 'Go home', 'class' => 'text-primary']);
+
+        $result = (new Bootstrap5Renderer())->render($menu);
+
+        $this->assertStringContainsString('href="/home"', $result);
+        $this->assertStringContainsString('title="Go home"', $result);
+        // The renderer's nav-link class merges with the labelAttributes class.
+        $this->assertMatchesRegularExpression('/class="[^"]*\bnav-link\b[^"]*\btext-primary\b[^"]*"/', $result);
+    }
+
+    public function testLabelAttributesOnBootstrap5ActiveLabel(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home', ['active' => true])->setLabelAttributes(['title' => 'Here']);
+
+        $result = (new Bootstrap5Renderer(['currentAsLink' => false]))->render($menu);
+
+        $this->assertStringContainsString('aria-current="page"', $result);
+        // The active item renders as <span>, and labelAttributes land on it.
+        $this->assertMatchesRegularExpression('/<span[^>]*title="Here"[^>]*>Home<\/span>/', $result);
+    }
+
+    public function testRolesAppliedByBootstrap5Renderer(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home');
+
+        $result = (new Bootstrap5Renderer())->render($menu, ['roles' => true]);
+
+        $this->assertStringContainsString('role="menubar"', $result);
+        $this->assertStringContainsString('role="menuitem"', $result);
+    }
+
+    public function testLabelAttributesOnBootstrap5SidebarLeaf(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home')->setLabelAttributes(['title' => 'Go home', 'class' => 'text-primary']);
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        $this->assertStringContainsString('title="Go home"', $result);
+        $this->assertMatchesRegularExpression('/class="[^"]*\bnav-link\b[^"]*\btext-primary\b/', $result);
+    }
+
+    public function testLabelAttributesOnBootstrap5SidebarPlaceholderToggle(): void
+    {
+        $menu = Menu::create();
+        $branch = $menu->addItem('Features', '#', ['id' => 'features']);
+        $branch->setLabelAttributes(['title' => 'Open features', 'class' => 'fw-bold']);
+        $branch->getSubMenu()->addItem('Resolvers', '/resolvers');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        // labelAttributes land on the toggle <a>, not on the <li> or the collapse <div>. The test
+        // menu has only one toggle anchor, so finding both attributes on an <a> is sufficient
+        // (the renderer emits data-bs-toggle before title in attribute order).
+        $this->assertMatchesRegularExpression('/<a\b[^>]*\bdata-bs-toggle="collapse"[^>]*>/', $result);
+        $this->assertMatchesRegularExpression('/<a\b[^>]*\btitle="Open features"[^>]*>/', $result);
+        $this->assertStringContainsString('fw-bold', $result);
+    }
+
+    public function testLabelAttributesOnBootstrap5SidebarNavigableBranch(): void
+    {
+        $menu = Menu::create();
+        $branch = $menu->addItem('Products', '/products', ['id' => 'products']);
+        $branch->setLabelAttributes(['title' => 'Browse products']);
+        $branch->getSubMenu()->addItem('Books', '/books');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        // labelAttributes apply to the navigable anchor, not the separate collapse toggle button.
+        $this->assertMatchesRegularExpression('/<a[^>]*href="\/products"[^>]*title="Browse products"/', $result);
+        $this->assertDoesNotMatchRegularExpression('/<button[^>]*title="Browse products"/', $result);
+    }
+
+    public function testLabelAttributesOnNavbarRenderer(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home')->setLabelAttributes(['title' => 'Go home', 'class' => 'text-primary']);
+
+        $result = (new NavbarRenderer())->render($menu);
+
+        // NavbarRenderer extends Bootstrap5Renderer, so the fix flows through inheritance.
+        $this->assertStringContainsString('title="Go home"', $result);
+        $this->assertMatchesRegularExpression('/class="[^"]*\bnav-link\b[^"]*\btext-primary\b/', $result);
     }
 }


### PR DESCRIPTION
## What

`labelAttributes` (the new #15 item option) and the renderer `roles` option are documented as applying to the rendered link/label element. In practice they only worked in `StringTemplateRenderer` — every Bootstrap5-family renderer overrode the link/label rendering path and silently dropped both.

## Why it matters

- `labelAttributes` is the documented way to put `title`, custom data-*, target/rel, extra classes etc. on the rendered `<a>` / `<span>` without coupling them to the link or to the `<li>`. With this dropped in 3/4 renderers, users in BS5 land had no working API for it (they had to fall back to `Link::create($url, [...])`, which works because the BS5 renderers do consume the link's own attributes, but that conflates the URL and its presentation).
- The `roles` option (WAI-ARIA menubar pattern, also from #15) was similarly dropped — `role="menuitem"` / `aria-haspopup` never reached BS5 links.

## How

Routes the existing `mergeLabelAttributes()` and `applyMenuItemRole()` helpers (already on `StringTemplateRenderer`) through the overridden rendering paths:

- `Bootstrap5Renderer::renderContent` — both the active-as-label `<span>` and the link `<a>` branches.
- `Bootstrap5SidebarRenderer::renderLeaf` — both branches.
- `Bootstrap5SidebarRenderer::renderToggle` — the placeholder (`#`) branch toggle `<a>`; signature now takes the item, updated at the single caller.
- `Bootstrap5SidebarRenderer::renderNavigableBranch` — the navigable anchor only, not the separate collapse toggle button (per the doc: it's the *link/label* element, not the toggle chrome).

`NavbarRenderer` inherits from `Bootstrap5Renderer`, so it picks the fix up automatically.

## Coverage

`RendererFeaturesTest` previously asserted these behaviors for `StringTemplateRenderer` only. Added 7 cases covering the renderer paths that were missing — `labelAttributes` on Bootstrap5 link, Bootstrap5 active label, Sidebar leaf, Sidebar placeholder toggle, Sidebar navigable branch (anchor yes, button no), NavbarRenderer (inheritance smoke test), and `roles=true` applying `role="menuitem"` in Bootstrap5Renderer.
