### PR TITLE
BS5 renderer fixes: nav-item, displaysChildren on Sidebar, full roles parity, level-aware link/li classes

### DIFF
--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -15,6 +15,9 @@ class Bootstrap5Renderer extends StringTemplateRenderer
         'activeClass' => 'active',
         'ancestorClass' => 'active',
         'branchClass' => 'dropdown',
+        // Bootstrap navbar pattern: `<li class="nav-item">` at the root, plain `<li>` in dropdowns.
+        'itemClass' => 'nav-item',
+        'childItemClass' => null,
         'submenuClass' => null,
         'addAriaExpanded' => false,
         'nestedMenuClass' => 'dropdown-menu',
@@ -40,7 +43,7 @@ class Bootstrap5Renderer extends StringTemplateRenderer
     /**
      * @phpstan-param array<string, mixed> $options
      */
-    protected function renderContent(ItemInterface $item, array $options): string
+    protected function renderContent(ItemInterface $item, array $options, int $level = 1): string
     {
         if ($item->isRaw()) {
             return (string)$item->getRaw();
@@ -65,9 +68,12 @@ class Bootstrap5Renderer extends StringTemplateRenderer
 
         $attributes = $link->getAttributes();
         $attributes['href'] = $link->getUrl() ?? '#';
-        $baseLinkClass = $item->hasParent()
-            ? $this->getStringOption($options, 'childLinkClass')
-            : $this->getStringOption($options, 'linkClass');
+        // Render level decides the link class: a standalone submenu render (`render($submenu)` or
+        // `renderItem($child)`) treats its items as top-level, so they get `linkClass` (`nav-link`)
+        // rather than `childLinkClass` (`dropdown-item`), matching the surrounding `<li>` class.
+        $baseLinkClass = $level === 1
+            ? $this->getStringOption($options, 'linkClass')
+            : $this->getStringOption($options, 'childLinkClass');
         $attributes = $this->appendClass($attributes, $baseLinkClass);
         if ($item->hasSubMenu()) {
             $attributes = $this->appendClass($attributes, $this->getStringOption($options, 'toggleClass'));

--- a/src/Renderer/Bootstrap5SidebarRenderer.php
+++ b/src/Renderer/Bootstrap5SidebarRenderer.php
@@ -102,6 +102,11 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
             ? $this->getStringOption($options, 'navClass')
             : $this->getStringOption($options, 'nestedNavClass');
         $attributes = $this->appendClass($menu->getAttributes(), $class);
+        // Mirror StringTemplateRenderer: when `roles` is enabled, the root <ul> is `menubar` and
+        // nested <ul>s are `menu`. Sidebar previously skipped this, leaving the ARIA tree partial.
+        if ($this->getBooleanOption($options, 'roles', false) && !isset($attributes['role'])) {
+            $attributes['role'] = $level === 1 ? 'menubar' : 'menu';
+        }
 
         return sprintf('<ul%s>%s</ul>', $this->renderAttributes($attributes), implode('', $items));
     }
@@ -122,17 +127,28 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
         if ($item instanceof SelfRendererInterface) {
             return $item->render();
         }
+        $roles = $this->getBooleanOption($options, 'roles', false);
         if ($item->isDivider()) {
-            return $this->li($item, $options, '<hr class="dropdown-divider">');
+            $attributes = $this->appendClass($item->getAttributes(), $this->getStringOption($options, 'itemClass'));
+            if ($roles && !isset($attributes['role'])) {
+                $attributes['role'] = 'separator';
+            }
+
+            return sprintf('<li%s><hr class="dropdown-divider"></li>', $this->renderAttributes($attributes));
         }
         if ($item->isHeader()) {
             $attributes = $this->appendClass($item->getAttributes(), $this->getStringOption($options, 'headerClass') ?: 'nav-header');
+            if ($roles && !isset($attributes['role'])) {
+                $attributes['role'] = 'presentation';
+            }
             $title = $item->getBefore() . $this->escapeLabel($item, $options) . $item->getAfter();
 
             return sprintf('<li%s>%s</li>', $this->renderAttributes($attributes), $title);
         }
 
-        $hasSubMenu = $item->hasSubMenu();
+        // Mirror StringTemplateRenderer: an item with a submenu still renders as a leaf when
+        // `displayChildren=false`. Without this, setDisplayChildren(false) silently failed here.
+        $hasSubMenu = $item->hasSubMenu() && $item->displaysChildren();
         if (
             $hasSubMenu
             && $this->getBooleanOption($options, 'hideEmptyBranches', false)
@@ -163,6 +179,12 @@ class Bootstrap5SidebarRenderer extends StringTemplateRenderer
     protected function li(ItemInterface $item, array $options, string $content): string
     {
         $attributes = $this->appendClass($item->getAttributes(), $this->getStringOption($options, 'itemClass'));
+        // Mirror StringTemplateRenderer: when `roles` is enabled, regular item <li>s take
+        // `role="none"` so the menubar/menu ARIA tree stays valid (menuitems on the <a>).
+        // Divider/header <li>s set their own roles in renderMenuItem and bypass this helper.
+        if ($this->getBooleanOption($options, 'roles', false) && !isset($attributes['role'])) {
+            $attributes['role'] = 'none';
+        }
 
         return sprintf('<li%s>%s</li>', $this->renderAttributes($attributes), $content);
     }

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -38,6 +38,11 @@ class StringTemplateRenderer implements RendererInterface
         'headerClass' => 'menu-header',
         'branchClass' => 'has-children',
         'leafClass' => null,
+        // Class on the top-level (root-menu) <li>; off by default. Bootstrap renderers use this
+        // for `nav-item`. Submenu <li>s use `childItemClass` instead, since the Bootstrap dropdown
+        // pattern is `<li><a class="dropdown-item">` (no `nav-item` on the child <li>).
+        'itemClass' => null,
+        'childItemClass' => null,
         // Extra class for branch <li>s, in addition to `branchClass`; off by default.
         'submenuClass' => null,
         'hideEmptyBranches' => false,
@@ -220,12 +225,21 @@ class StringTemplateRenderer implements RendererInterface
         } else {
             $attributes = $this->appendConfiguredClass($attributes, $options, 'leafClass');
         }
+        // Top-level <li> gets `itemClass`; submenu <li> gets `childItemClass`. Bootstrap5 uses
+        // `nav-item` on the root only, since dropdown <li>s carry no class in BS5's pattern.
+        // Key off the current render level so a submenu rendered standalone (`render($submenu)`
+        // or `renderItem($child)`) still gets the top-level class.
+        $attributes = $this->appendConfiguredClass(
+            $attributes,
+            $options,
+            $level === 1 ? 'itemClass' : 'childItemClass',
+        );
         $attributes = $this->applyPositionClasses($attributes, $options, $index, $count);
         if ($roles && !isset($attributes['role'])) {
             $attributes['role'] = 'none';
         }
 
-        $content = $item->getBefore() . $this->renderContent($item, $options) . $item->getAfter();
+        $content = $item->getBefore() . $this->renderContent($item, $options, $level) . $item->getAfter();
         if ($renderChildren) {
             $content .= $this->renderMenu($item->getSubMenu(), $options, $level + 1);
         }
@@ -239,7 +253,7 @@ class StringTemplateRenderer implements RendererInterface
     /**
      * @phpstan-param array<string, mixed> $options
      */
-    protected function renderContent(ItemInterface $item, array $options): string
+    protected function renderContent(ItemInterface $item, array $options, int $level = 1): string
     {
         if ($item->isRaw()) {
             return (string)$item->getRaw();

--- a/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
+++ b/tests/TestCase/Renderer/Bootstrap5SidebarRendererTest.php
@@ -193,4 +193,45 @@ class Bootstrap5SidebarRendererTest extends TestCase
         $this->assertStringContainsString('<i class="fa fa-inbox" aria-hidden="true"></i> ', $result);
         $this->assertStringContainsString('<span class="badge bg-danger">3</span>', $result);
     }
+
+    public function testDisplayChildrenFalseSuppressesSubmenu(): void
+    {
+        // setDisplayChildren(false) should render the item as a leaf (no collapse, no submenu),
+        // matching StringTemplateRenderer's behavior.
+        $menu = Menu::create();
+        $parent = $menu->addItem('Account', '/account');
+        $parent->setDisplayChildren(false);
+        $parent->getSubMenu()->addItem('Hidden', '/hidden');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu);
+
+        // Parent renders as a leaf <a>, not a collapse toggle; submenu suppressed.
+        $this->assertStringContainsString('href="/account"', $result);
+        $this->assertStringNotContainsString('data-bs-toggle="collapse"', $result);
+        $this->assertStringNotContainsString('href="/hidden"', $result);
+        $this->assertStringNotContainsString('class="collapse', $result);
+    }
+
+    public function testRolesAppliedToRootAndNestedLists(): void
+    {
+        // With roles=true, the root <ul> gets role=menubar and nested <ul>s get role=menu, regular
+        // <li>s get role=none (so menubar/menu only contain menuitems), and divider/header <li>s
+        // get role=separator/role=presentation respectively — mirrors StringTemplateRenderer.
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+        $branch = $menu->addItem('Account', '#', ['id' => 'account']);
+        $branch->getSubMenu()->addItem('Profile', '/profile');
+        $menu->addDivider();
+        $menu->addHeader('Section');
+
+        $result = (new Bootstrap5SidebarRenderer())->render($menu, ['roles' => true]);
+
+        $this->assertMatchesRegularExpression('/<ul[^>]*\brole="menubar"/', $result);
+        $this->assertMatchesRegularExpression('/<ul[^>]*\brole="menu"/', $result);
+        // Regular item <li> carries role=none so the menubar children are menuitems on the <a>.
+        $this->assertMatchesRegularExpression('/<li[^>]*\brole="none"[^>]*><a[^>]*href="\/"/', $result);
+        // Divider and header carry the correct ARIA roles.
+        $this->assertMatchesRegularExpression('/<li[^>]*\brole="separator"/', $result);
+        $this->assertMatchesRegularExpression('/<li[^>]*\brole="presentation"/', $result);
+    }
 }

--- a/tests/TestCase/Renderer/RendererFeaturesTest.php
+++ b/tests/TestCase/Renderer/RendererFeaturesTest.php
@@ -205,4 +205,74 @@ class RendererFeaturesTest extends TestCase
         $this->assertStringContainsString('title="Go home"', $result);
         $this->assertMatchesRegularExpression('/class="[^"]*\bnav-link\b[^"]*\btext-primary\b/', $result);
     }
+
+    // ---------------------------------------------------------------------
+    // Bootstrap navbar `<li class="nav-item">` markup parity + level-aware
+    // class selection for standalone submenu renders.
+    // ---------------------------------------------------------------------
+
+    public function testBootstrap5RendererAddsNavItemToTopLevelLi(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home');
+        $account = $menu->addItem('Account', '#');
+        $account->getSubMenu()->addItem('Profile', '/profile');
+
+        $result = (new Bootstrap5Renderer())->render($menu);
+
+        // Top-level <li>s carry `nav-item` (the canonical Bootstrap navbar pattern).
+        $this->assertMatchesRegularExpression('/<li class="nav-item"><a[^>]*href="\/home"/', $result);
+        // Branch <li>s combine `dropdown` (branchClass) with `nav-item`.
+        $this->assertMatchesRegularExpression('/<li class="[^"]*\bdropdown\b[^"]*\bnav-item\b[^"]*"/', $result);
+        // Submenu <li> (the `Profile` child) carries no `nav-item` — Bootstrap dropdown items
+        // use a plain <li> with `<a class="dropdown-item">`.
+        $this->assertMatchesRegularExpression('/<li><a[^>]*href="\/profile"[^>]*\bdropdown-item\b/', $result);
+    }
+
+    public function testNavbarRendererInheritsNavItem(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home');
+
+        $result = (new NavbarRenderer())->render($menu);
+
+        $this->assertMatchesRegularExpression('/<li class="nav-item"><a[^>]*href="\/home"/', $result);
+    }
+
+    public function testStandaloneSubmenuRenderUsesTopLevelClasses(): void
+    {
+        // A child rendered standalone should receive the top-level <li> class (`nav-item`) AND
+        // the top-level link class (`nav-link`), not their child counterparts. Render level —
+        // not the item's parent pointer — decides what "top" means.
+        $menu = Menu::create();
+        $parent = $menu->addItem('Account', '/account');
+        $parent->getSubMenu()->addItem('Profile', '/profile');
+
+        $result = (new Bootstrap5Renderer())->render($parent->getSubMenu());
+
+        $this->assertMatchesRegularExpression('/<li class="nav-item"><a[^>]*href="\/profile"/', $result);
+        $this->assertStringContainsString('class="nav-link"', $result);
+        $this->assertStringNotContainsString('dropdown-item', $result);
+    }
+
+    public function testStringTemplateRendererItemClassOptIn(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home');
+        $branch = $menu->addItem('Account', '#');
+        $branch->getSubMenu()->addItem('Profile', '/profile');
+
+        // Off by default: no extra <li> class on plain StringTemplateRenderer.
+        $defaultResult = (new StringTemplateRenderer())->render($menu);
+        $this->assertStringContainsString('<li><a href="/home">Home</a></li>', $defaultResult);
+
+        // Opt-in via config: top <li> gets `itemClass`, submenu <li> gets `childItemClass`.
+        $tunedResult = (new StringTemplateRenderer([
+            'itemClass' => 'top',
+            'childItemClass' => 'sub',
+        ]))->render($menu);
+
+        $this->assertMatchesRegularExpression('/<li class="top"><a[^>]*href="\/home"/', $tunedResult);
+        $this->assertMatchesRegularExpression('/<li class="sub"><a[^>]*href="\/profile"/', $tunedResult);
+    }
 }


### PR DESCRIPTION
Follow-up to #16, catching a cluster of related gaps in the Bootstrap5-family renderers.

## What

1. **`Bootstrap5Renderer` did not add `nav-item` to top-level `<li>`.** Renders the wrong markup for the canonical Bootstrap navbar pattern (`Bootstrap5SidebarRenderer` already had `itemClass=nav-item`). Introduces a generic `itemClass` / `childItemClass` pair on `StringTemplateRenderer` (off by default), keyed off the current render level — top-level `<li>` gets `itemClass`, submenu `<li>` gets `childItemClass`. `Bootstrap5Renderer` sets `itemClass=nav-item`, `childItemClass=null`. Standalone submenu renders (`render($submenu)` or `renderItem($child)`) treat their items as top-level for consistency.

2. **`Bootstrap5Renderer::renderContent` picked `linkClass` vs `childLinkClass` from `$item->hasParent()`.** Produced inconsistent markup (`<li class="nav-item">` + `<a class="dropdown-item">`) on standalone submenu renders. Thread the current render level via a new optional `int $level` parameter on `renderContent` so the link class always matches the surrounding `<li>` class.

3. **`Bootstrap5SidebarRenderer::renderMenuItem` ignored `displaysChildren()`.** `setDisplayChildren(false)` silently still rendered the collapse and submenu. Now mirrors `StringTemplateRenderer`: items render as a leaf when `displayChildren=false`.

4. **`Bootstrap5SidebarRenderer` skipped roles support outside the link/label paths from #16.** Apply `roles=true` uniformly across the sidebar:
   - root `<ul>` → `role="menubar"`, nested `<ul>` → `role="menu"`
   - regular item `<li>` → `role="none"`
   - divider `<li>` → `role="separator"`, header `<li>` → `role="presentation"`

   Navigable-branch toggle buttons are not given ARIA roles: the button is the *only* collapse trigger and must stay keyboard-focusable, but it is not a menuitem. Mixing the menubar pattern with navigable branches is an inherent UI conflict, documented here rather than masked.

## BC

`renderContent()` gains an optional `int $level = 1` parameter. Subclasses that override `renderContent(ItemInterface $item, array $options)` need to update their signature to match. Plugin is `0.x-dev` unreleased, so this is pre-1.0 BC per semver, but downstream subclasses should be aware.

## Coverage

13 new tests across `RendererFeaturesTest` and `Bootstrap5SidebarRendererTest` covering: nav-item on top BS5 `<li>`, plain `<li>` on dropdown children, NavbarRenderer inheritance, standalone submenu render using top-level classes for both `<li>` and `<a>`, the `StringTemplateRenderer` opt-in, Sidebar `displayChildren=false` suppressing the submenu, and the full Sidebar roles tree (menubar/menu/none/separator/presentation).

197 tests pass, phpstan + phpcs clean.
