### PR TITLE
Bootstrap5Renderer: honor displayChildren=false on the anchor

### DIFF
--- a/src/Renderer/Bootstrap5Renderer.php
+++ b/src/Renderer/Bootstrap5Renderer.php
@@ -75,7 +75,10 @@ class Bootstrap5Renderer extends StringTemplateRenderer
             ? $this->getStringOption($options, 'linkClass')
             : $this->getStringOption($options, 'childLinkClass');
         $attributes = $this->appendClass($attributes, $baseLinkClass);
-        if ($item->hasSubMenu()) {
+        // Only treat as a dropdown when the submenu will actually render. Without the
+        // displaysChildren() guard, an item with setDisplayChildren(false) still got
+        // dropdown-toggle + data-bs-toggle even though its submenu is suppressed.
+        if ($item->hasSubMenu() && $item->displaysChildren()) {
             $attributes = $this->appendClass($attributes, $this->getStringOption($options, 'toggleClass'));
             $toggleAttribute = $this->getStringOption($options, 'toggleAttribute');
             if ($toggleAttribute !== '') {

--- a/tests/TestCase/Renderer/RendererFeaturesTest.php
+++ b/tests/TestCase/Renderer/RendererFeaturesTest.php
@@ -255,6 +255,25 @@ class RendererFeaturesTest extends TestCase
         $this->assertStringNotContainsString('dropdown-item', $result);
     }
 
+    public function testBootstrap5RendererHonorsDisplayChildrenFalse(): void
+    {
+        // setDisplayChildren(false) should render the item as a leaf — no dropdown-toggle class,
+        // no data-bs-toggle, no submenu. Previously Bootstrap5Renderer kept the dropdown wiring
+        // even though the submenu was suppressed, producing a toggle to nothing.
+        $menu = Menu::create();
+        $parent = $menu->addItem('Account', '/account');
+        $parent->setDisplayChildren(false);
+        $parent->getSubMenu()->addItem('Hidden', '/hidden');
+
+        $result = (new Bootstrap5Renderer())->render($menu);
+
+        $this->assertStringContainsString('href="/account"', $result);
+        $this->assertStringNotContainsString('dropdown-toggle', $result);
+        $this->assertStringNotContainsString('data-bs-toggle', $result);
+        $this->assertStringNotContainsString('href="/hidden"', $result);
+        $this->assertStringNotContainsString('dropdown-menu', $result);
+    }
+
     public function testStringTemplateRendererItemClassOptIn(): void
     {
         $menu = Menu::create();


### PR DESCRIPTION
Caught during a follow-up audit after #18.

## What

`Bootstrap5Renderer::renderContent` keyed the `dropdown-toggle` class, `data-bs-toggle` attribute and `aria-expanded` purely off `$item->hasSubMenu()`, ignoring `$item->displaysChildren()`. So an item with `setDisplayChildren(false)`:

- correctly rendered as a leaf `<li>` (no submenu wrapper — `StringTemplateRenderer::renderMenuItem` already had the guard),
- but the `<a>` still carried `class="nav-link dropdown-toggle"`, `data-bs-toggle="dropdown"`, `role="button"` and `aria-expanded` — a dropdown toggle to nothing.

`Bootstrap5SidebarRenderer` got the same fix in #18; this lines `Bootstrap5Renderer` up with it.

## Coverage

Adds `testBootstrap5RendererHonorsDisplayChildrenFalse` asserting the leaf-mode anchor: no `dropdown-toggle`, no `data-bs-toggle`, no submenu, no hidden child link.

198 tests pass, phpstan + phpcs clean.

## Other findings from the audit (out of scope, separate concern)

These are state-mutation issues worth a separate PR; flagging here so they aren't lost:

- `NavbarRenderer::$collapseInstances` — class-level static counter leaks across renders in the same request, producing non-deterministic ids unless an explicit `collapseId` is passed.
- `StringTemplateRenderer::render` and `BreadcrumbRenderer::render` — passing `templates` via per-call options does `setConfig('templates', …)`, permanently mutating the renderer instance. A subsequent render without `templates` reuses the mutated state.

