### PR TITLE
Isolate per-call `templates` option from renderer state

### DIFF
--- a/src/Renderer/BreadcrumbRenderer.php
+++ b/src/Renderer/BreadcrumbRenderer.php
@@ -33,44 +33,56 @@ class BreadcrumbRenderer extends StringTemplateRenderer
      */
     public function render(MenuInterface $menu, array $options = []): string
     {
-        if (isset($options['templates']) && is_array($options['templates'])) {
-            $this->setConfig('templates', $options['templates'] + $this->getConfig('templates'));
+        // Per-call template overrides must not bleed into the renderer instance for subsequent
+        // renders. Push the snapshot first so the finally{pop()} is always balanced, then apply
+        // overrides + render inside try so a failing add() still restores state.
+        $hasOverrides = isset($options['templates']) && is_array($options['templates']) && $options['templates'] !== [];
+        if ($hasOverrides) {
+            $this->templater()->push();
         }
+        try {
+            if ($hasOverrides) {
+                $this->templater()->add($options['templates']);
+            }
+            $path = $options['path'] ?? null;
+            if (!is_array($path)) {
+                $activeItem = $menu->getActiveItem();
+                if ($activeItem === null) {
+                    return '';
+                }
 
-        $path = $options['path'] ?? null;
-        if (!is_array($path)) {
-            $activeItem = $menu->getActiveItem();
-            if ($activeItem === null) {
-                return '';
+                $path = [];
+                while ($activeItem !== null) {
+                    $path[] = $activeItem;
+                    $activeItem = $activeItem->getParent();
+                }
+                $path = array_reverse($path);
             }
 
-            $path = [];
-            while ($activeItem !== null) {
-                $path[] = $activeItem;
-                $activeItem = $activeItem->getParent();
-            }
-            $path = array_reverse($path);
-        }
+            $items = [];
+            $count = count($path);
+            foreach ($path as $index => $item) {
+                if (!$item instanceof ItemInterface) {
+                    continue;
+                }
 
-        $items = [];
-        $count = count($path);
-        foreach ($path as $index => $item) {
-            if (!$item instanceof ItemInterface) {
-                continue;
+                $items[] = $this->renderBreadcrumbItem($item, $options, $index === $count - 1);
             }
 
-            $items[] = $this->renderBreadcrumbItem($item, $options, $index === $count - 1);
+            $attributes = $this->appendClass([], (string)($options['menuClass'] ?? $this->getConfig('menuClass')));
+
+            $ariaLabel = (string)($options['ariaLabel'] ?? $this->getConfig('ariaLabel'));
+
+            return $this->templater()->format('menuWrapper', [
+                'ariaLabel' => htmlspecialchars($ariaLabel, ENT_QUOTES, 'UTF-8'),
+                'attributes' => $this->renderAttributes($attributes),
+                'items' => implode('', $items),
+            ]);
+        } finally {
+            if ($hasOverrides) {
+                $this->templater()->pop();
+            }
         }
-
-        $attributes = $this->appendClass([], (string)($options['menuClass'] ?? $this->getConfig('menuClass')));
-
-        $ariaLabel = (string)($options['ariaLabel'] ?? $this->getConfig('ariaLabel'));
-
-        return $this->templater()->format('menuWrapper', [
-            'ariaLabel' => htmlspecialchars($ariaLabel, ENT_QUOTES, 'UTF-8'),
-            'attributes' => $this->renderAttributes($attributes),
-            'items' => implode('', $items),
-        ]);
     }
 
     /**

--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -11,7 +11,6 @@ use Menu\Item\SelfRendererInterface;
 use Menu\MenuInterface;
 use function array_filter;
 use function array_map;
-use function array_merge;
 use function array_unique;
 use function Cake\I18n\__;
 use function count;
@@ -84,11 +83,22 @@ class StringTemplateRenderer implements RendererInterface
      */
     public function render(MenuInterface $menu, array $options = []): string
     {
-        if (isset($options['templates']) && is_array($options['templates'])) {
-            $this->setConfig('templates', array_merge($this->getConfig('templates'), $options['templates']));
+        // Per-call template overrides must not bleed into the renderer instance for subsequent
+        // renders. Push the snapshot first so the finally{pop()} is always balanced, then apply
+        // overrides + render inside try so a failing add() (invalid override) still restores state.
+        $hasOverrides = isset($options['templates']) && is_array($options['templates']) && $options['templates'] !== [];
+        if (!$hasOverrides) {
+            return $this->renderMenu($menu, $options, 1);
         }
 
-        return $this->renderMenu($menu, $options, 1);
+        $this->templater()->push();
+        try {
+            $this->templater()->add($options['templates']);
+
+            return $this->renderMenu($menu, $options, 1);
+        } finally {
+            $this->templater()->pop();
+        }
     }
 
     /**

--- a/tests/TestCase/Renderer/RendererFeaturesTest.php
+++ b/tests/TestCase/Renderer/RendererFeaturesTest.php
@@ -8,8 +8,10 @@ use Cake\TestSuite\TestCase;
 use Menu\Menu;
 use Menu\Renderer\Bootstrap5Renderer;
 use Menu\Renderer\Bootstrap5SidebarRenderer;
+use Menu\Renderer\BreadcrumbRenderer;
 use Menu\Renderer\NavbarRenderer;
 use Menu\Renderer\StringTemplateRenderer;
+use Throwable;
 
 class RendererFeaturesTest extends TestCase
 {
@@ -274,5 +276,65 @@ class RendererFeaturesTest extends TestCase
 
         $this->assertMatchesRegularExpression('/<li class="top"><a[^>]*href="\/home"/', $tunedResult);
         $this->assertMatchesRegularExpression('/<li class="sub"><a[^>]*href="\/profile"/', $tunedResult);
+    }
+
+    // ---------------------------------------------------------------------
+    // Per-call `templates` option must not leak into the renderer instance.
+    // Previously render() called setConfig('templates', merged), which
+    // permanently mutated the renderer; a subsequent render without the
+    // option reused the mutated state.
+    // ---------------------------------------------------------------------
+
+    public function testPerCallTemplatesDoNotLeakInStringTemplateRenderer(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home');
+
+        $renderer = new StringTemplateRenderer();
+        $withOverride = $renderer->render($menu, [
+            'templates' => ['menuWrapper' => '<nav><ul{{attributes}}>{{items}}</ul></nav>'],
+        ]);
+        $withoutOverride = $renderer->render($menu);
+
+        $this->assertStringContainsString('<nav><ul>', $withOverride);
+        // Subsequent render without the override must produce the original markup.
+        $this->assertSame('<ul><li><a href="/home">Home</a></li></ul>', $withoutOverride);
+    }
+
+    public function testPerCallTemplatesDoNotLeakInBreadcrumbRenderer(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home', ['active' => true]);
+
+        $renderer = new BreadcrumbRenderer();
+        $withOverride = $renderer->render($menu, [
+            'templates' => ['menuWrapper' => '<ol>{{items}}</ol>'],
+        ]);
+        $withoutOverride = $renderer->render($menu);
+
+        $this->assertStringContainsString('<ol>', $withOverride);
+        // Default template restored after the overridden render.
+        $this->assertStringContainsString('<nav aria-label="breadcrumb"><ol', $withoutOverride);
+        $this->assertStringNotContainsString('<ol><li', $withoutOverride);
+    }
+
+    public function testTemplatesRestoredWhenRenderThrows(): void
+    {
+        // push/pop must restore templates even if rendering fails. Use an invalid template token
+        // so format() throws, then confirm a subsequent render reverts to the default.
+        $renderer = new StringTemplateRenderer();
+        $menu = Menu::create();
+        $menu->addItem('Home', '/home');
+
+        try {
+            $renderer->render($menu, [
+                'templates' => ['menuWrapper' => '<broken {{ no_close'],
+            ]);
+        } catch (Throwable) {
+            // Expected: malformed template.
+        }
+
+        $clean = $renderer->render($menu);
+        $this->assertSame('<ul><li><a href="/home">Home</a></li></ul>', $clean);
     }
 }


### PR DESCRIPTION
Follow-up audit of #18 / #19 surfaced two state-leak issues in the base renderers. This PR fixes one of them; the other is left as a documented design trade-off.

## Fixed: per-call `templates` option bleeds into renderer state

`StringTemplateRenderer::render` and `BreadcrumbRenderer::render` applied per-call `templates` overrides via `setConfig('templates', merged)`. Permanently mutates the renderer instance — a subsequent `render()` without the option reuses the mutated state. Callers reusing the same renderer get non-deterministic output.

Switched to the CakePHP templater stack (`push`/`add`/`pop`):

- `push()` snapshots the current templates
- `add()` applies the overrides
- `pop()` (in `finally`) always restores the snapshot

`push()` is called outside the `try` block so `finally{pop()}` stays balanced even if `add()` rejects an invalid override (per codex P2 in review).

## Coverage

Three new `RendererFeaturesTest` cases:

- `testPerCallTemplatesDoNotLeakInStringTemplateRenderer` — render with override + render without; second result uses defaults.
- `testPerCallTemplatesDoNotLeakInBreadcrumbRenderer` — same for breadcrumbs.
- `testTemplatesRestoredWhenRenderThrows` — a render that throws still restores defaults.

200 tests pass, phpstan + phpcs clean.

## Not fixed in this PR: `NavbarRenderer::$collapseInstances` static counter

The static counter that auto-numbers `navbar-collapse-N` when no explicit `collapseId` is passed leaks across renders in the same request, producing non-idempotent output. Considered switching it to instance-scoped + reset per `render()`, but that re-introduces id collisions for pages that render two navbars from the same renderer without explicit `collapseId` — which is the original ergonomic the static was designed for. The existing `testGeneratesUniqueCollapseIdsForMultipleNavbars` test asserts that ergonomic.

Cleanest path would be: require explicit `collapseId` when rendering multiple navbars per page and drop the auto-counter entirely. Bigger API decision, not bundled here.

