### PR TITLE
Fix parent synchronization and explicit exact URL matching

### DIFF
--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -71,7 +71,7 @@ class Item implements ItemInterface, StateResetInterface
 
     protected ?bool $ignoreQueryString = null;
 
-    protected bool $fuzzyMatch = false;
+    protected ?bool $fuzzyMatch = null;
 
     protected bool $expanded = false;
 
@@ -504,6 +504,11 @@ class Item implements ItemInterface, StateResetInterface
     }
 
     public function isFuzzyMatch(): bool
+    {
+        return $this->fuzzyMatch ?? false;
+    }
+
+    public function getFuzzyMatchSetting(): ?bool
     {
         return $this->fuzzyMatch;
     }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -16,6 +16,7 @@ use Menu\Resolver\ContextAwareResolverInterface;
 use Menu\Resolver\ResolverCollectionInterface;
 use Menu\Resolver\ResolverContext;
 use Menu\Resolver\ResolverInterface;
+use ReflectionObject;
 
 class Menu implements MenuInterface
 {
@@ -90,7 +91,7 @@ class Menu implements MenuInterface
                     'submenuAttributes' => $itemConfig['submenu']['attributes'] ?? [],
                     'matchRoutes' => $itemConfig['matchRoutes'] ?? [],
                     'ignoreQueryString' => $itemConfig['ignoreQueryString'] ?? null,
-                    'fuzzy' => $itemConfig['fuzzy'] ?? false,
+                    'fuzzy' => $itemConfig['fuzzy'] ?? null,
                     'displayChildren' => $itemConfig['displayChildren'] ?? true,
                     'labelAttributes' => $itemConfig['labelAttributes'] ?? [],
                 ],
@@ -196,9 +197,7 @@ class Menu implements MenuInterface
     public function add(ItemInterface $item): static
     {
         $this->assertMutable();
-        if ($this->ownerItem !== null && !$item->hasParent()) {
-            $item->setParent($this->ownerItem);
-        }
+        $this->synchronizeItemParent($item);
 
         $this->assertUniqueItemTree($item);
         $this->items[] = $item;
@@ -234,7 +233,7 @@ class Menu implements MenuInterface
         // item would fail that reparenting mid-batch, so reject up-front.
         if ($this->ownerItem !== null) {
             foreach ($items as $item) {
-                if (!$item->hasParent() && $item->isFrozen()) {
+                if ($item->getParent() !== $this->ownerItem && $item->isFrozen()) {
                     throw new LogicException(
                         'Cannot add a frozen item to a submenu: reparenting it would require mutation.',
                     );
@@ -367,8 +366,8 @@ class Menu implements MenuInterface
             $ignoreQueryString = $options['ignoreQueryString'];
             $item->setIgnoreQueryString(is_bool($ignoreQueryString) ? $ignoreQueryString : null);
         }
-        if (!empty($options['fuzzy'])) {
-            $item->setFuzzyMatch();
+        if (array_key_exists('fuzzy', $options) && $options['fuzzy'] !== null) {
+            $item->setFuzzyMatch((bool)$options['fuzzy']);
         }
         if (array_key_exists('displayChildren', $options)) {
             $item->setDisplayChildren((bool)$options['displayChildren']);
@@ -439,10 +438,8 @@ class Menu implements MenuInterface
 
         $this->assertUniqueItems($validatedItems);
         $this->items = $validatedItems;
-        if ($this->ownerItem !== null) {
-            foreach ($this->items as $item) {
-                $item->setParent($this->ownerItem);
-            }
+        foreach ($this->items as $item) {
+            $this->synchronizeItemParent($item);
         }
 
         return $this;
@@ -476,6 +473,8 @@ class Menu implements MenuInterface
         $items = [];
         foreach ($this->items as $item) {
             if ($item->getId() === $id) {
+                $this->clearItemParent($item);
+
                 continue;
             }
             if ($item->hasSubMenu()) {
@@ -536,6 +535,7 @@ class Menu implements MenuInterface
     {
         foreach ($this->items as $index => $item) {
             if ($item->getKey() === $key) {
+                $this->clearItemParent($item);
                 array_splice($this->items, $index, 1);
 
                 return true;
@@ -723,9 +723,7 @@ class Menu implements MenuInterface
 
     protected function insertItemAt(ItemInterface $item, int $position): void
     {
-        if ($this->ownerItem !== null && !$item->hasParent()) {
-            $item->setParent($this->ownerItem);
-        }
+        $this->synchronizeItemParent($item);
         $this->assertUniqueItemTree($item);
         $position = max(0, min($position, count($this->items)));
         array_splice($this->items, $position, 0, [$item]);
@@ -921,12 +919,60 @@ class Menu implements MenuInterface
         $this->assertMutable();
         $this->ownerItem = $ownerItem;
         foreach ($this->items as $item) {
-            if (!$item->hasParent()) {
-                $item->setParent($ownerItem);
-            }
+            $this->synchronizeItemParent($item);
         }
 
         return $this;
+    }
+
+    protected function synchronizeItemParent(ItemInterface $item): void
+    {
+        $desiredParent = $this->ownerItem;
+        if ($item->getParent() === $desiredParent) {
+            return;
+        }
+        if ($item->isFrozen()) {
+            throw new LogicException('Cannot move a frozen item to a different parent.');
+        }
+        if ($desiredParent !== null) {
+            $item->setParent($desiredParent);
+
+            return;
+        }
+
+        $this->clearItemParent($item);
+    }
+
+    protected function clearItemParent(ItemInterface $item): void
+    {
+        if ($item instanceof Item) {
+            $detach = Closure::bind(
+                static function (Item $boundItem): void {
+                    $boundItem->parent = null;
+                },
+                null,
+                Item::class,
+            );
+            $detach($item);
+
+            return;
+        }
+
+        $reflection = new ReflectionObject($item);
+        while ($reflection !== false) {
+            if ($reflection->hasProperty('parent')) {
+                $property = $reflection->getProperty('parent');
+                $property->setAccessible(true);
+                $property->setValue($item, null);
+
+                return;
+            }
+            $reflection = $reflection->getParentClass();
+        }
+
+        throw new LogicException(
+            'Cannot detach a custom item from its parent when moving it to a root menu.',
+        );
     }
 
     protected function setOwnerItemDuringClone(ItemInterface $ownerItem): static

--- a/src/Resolver/UrlArrayResolver.php
+++ b/src/Resolver/UrlArrayResolver.php
@@ -88,10 +88,9 @@ class UrlArrayResolver implements ContextAwareResolverInterface
             }
         }
 
-        $fuzzy = $item instanceof Item
-            ? $item->isFuzzyMatch()
-            : false;
-        if (!$fuzzy) {
+        if ($item instanceof Item && $item->getFuzzyMatchSetting() !== null) {
+            $fuzzy = $item->isFuzzyMatch();
+        } else {
             $fuzzy = (bool)$this->getConfig('fuzzy');
         }
 

--- a/tests/TestCase/Item/ItemFeaturesTest.php
+++ b/tests/TestCase/Item/ItemFeaturesTest.php
@@ -72,4 +72,19 @@ class ItemFeaturesTest extends TestCase
         $this->assertFalse($item->displaysChildren());
         $this->assertSame(['title' => 'tip'], $item->getLabelAttributes());
     }
+
+    public function testFromArrayRoundTripPreservesExplicitNonFuzzySetting(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Parent', '/parent', [
+            'key' => 'parent',
+            'fuzzy' => false,
+        ]);
+
+        $rebuilt = Menu::fromArray($menu->toArray());
+        $item = $rebuilt->getByKey('parent');
+
+        $this->assertNotNull($item);
+        $this->assertFalse($item->isFuzzyMatch());
+    }
 }

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -211,6 +211,48 @@ class MenuTest extends TestCase
         $this->assertSame($child, $secondParent->getSubMenu()->get('child'));
     }
 
+    public function testSetItemsDetachesItemsMovedToRootMenu(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '#', ['id' => 'parent']);
+        $child = (new Item('Child', '/child'))->setId('child');
+
+        $parent->getSubMenu()->setItems([$child]);
+        $this->assertSame($parent, $child->getParent());
+
+        $menu->setItems([$child]);
+
+        $this->assertNull($child->getParent());
+        $this->assertSame($child, $menu->get('child'));
+    }
+
+    public function testAddReparentsItemMovedBetweenSubmenus(): void
+    {
+        $menu = Menu::create();
+        $firstParent = $menu->addItem('First', '#', ['id' => 'first']);
+        $secondParent = $menu->addItem('Second', '#', ['id' => 'second']);
+        $child = (new Item('Child', '/child'))->setId('child');
+
+        $firstParent->getSubMenu()->add($child);
+        $this->assertSame($firstParent, $child->getParent());
+
+        $secondParent->getSubMenu()->add($child);
+
+        $this->assertSame($secondParent, $child->getParent());
+    }
+
+    public function testRemoveDetachesRemovedItem(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '#', ['id' => 'parent']);
+        $child = $parent->getSubMenu()->addItem('Child', '/child', ['id' => 'child']);
+
+        $parent->getSubMenu()->remove('child');
+
+        $this->assertNull($child->getParent());
+        $this->assertNull($menu->get('child'));
+    }
+
     public function testCollectFlattensTheTree(): void
     {
         $menu = Menu::create();

--- a/tests/TestCase/Resolver/UrlArrayResolverTest.php
+++ b/tests/TestCase/Resolver/UrlArrayResolverTest.php
@@ -142,6 +142,25 @@ class UrlArrayResolverTest extends TestCase
         $this->assertFalse($item->isActive());
     }
 
+    public function testExplicitPerItemExactMatchOverridesGlobalFuzzySetting(): void
+    {
+        $item = (new Item('Articles', [
+            'controller' => 'Articles',
+        ]))->setFuzzyMatch(false);
+
+        $request = (new ServerRequest())->withAttribute('params', [
+            'controller' => 'Articles',
+            'action' => 'view',
+            'plugin' => null,
+            'pass' => [],
+        ]);
+
+        $resolver = new UrlArrayResolver($request, ['fuzzy' => true]);
+        $resolver->resolve($item);
+
+        $this->assertFalse($item->isActive());
+    }
+
     public function testMatchesPluginFalseAgainstNullRequestPlugin(): void
     {
         $item = new Item('Home', [


### PR DESCRIPTION
## Summary
- keep item parent pointers in sync when items are moved between menus, moved to the root, or removed
- respect per-item `setFuzzyMatch(false)` even when the resolver/helper defaults stay fuzzy
- add regression coverage for reparenting, detaching, and exact-match round-trips

## Details
The current `master` at `535b1b5` still had two issues:

1. Moving an item out of a submenu could leave `getParent()` pointing at the old owner, which breaks tree consumers such as breadcrumb/path extraction.
2. `UrlArrayResolver` could not distinguish "unset fuzzy preference" from an explicit `false`, so `setFuzzyMatch(false)` was ignored whenever the resolver config used `fuzzy => true`.

This patch centralizes parent synchronization in `Menu`, clears parent pointers when removing or moving items to a root menu, and preserves explicit fuzzy settings through `toArray()/fromArray()`.

## Validation
- `composer test`
- `composer stan`
- `composer cs-check`