### PR TITLE
Detach items cleanly when moving or removing them

### DIFF
--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -252,8 +252,15 @@ class Item implements ItemInterface, StateResetInterface
     public function add(ItemInterface $item): static
     {
         $this->assertMutable();
+        $subMenu = $this->getSubMenu();
+        if ($subMenu instanceof Menu) {
+            $subMenu->add($item);
+
+            return $this;
+        }
+
         $item->setParent($this);
-        $this->getSubMenu()->add($item);
+        $subMenu->add($item);
 
         return $this;
     }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -196,7 +196,8 @@ class Menu implements MenuInterface
     public function add(ItemInterface $item): static
     {
         $this->assertMutable();
-        if ($this->ownerItem !== null && !$item->hasParent()) {
+        $this->detachFromCurrentParentIfNeeded($item);
+        if ($this->ownerItem !== null && $item->getParent() !== $this->ownerItem) {
             $item->setParent($this->ownerItem);
         }
 
@@ -382,10 +383,26 @@ class Menu implements MenuInterface
         }
 
         $this->assertUniqueItems($validatedItems);
+        $preserved = [];
+        foreach ($validatedItems as $item) {
+            $preserved[spl_object_id($item)] = true;
+        }
+        foreach ($this->items as $existingItem) {
+            if (!isset($preserved[spl_object_id($existingItem)])) {
+                $this->clearParentReference($existingItem);
+            }
+        }
+
+        foreach ($validatedItems as $item) {
+            $this->detachFromCurrentParentIfNeeded($item);
+        }
+
         $this->items = $validatedItems;
         if ($this->ownerItem !== null) {
             foreach ($this->items as $item) {
-                $item->setParent($this->ownerItem);
+                if ($item->getParent() !== $this->ownerItem) {
+                    $item->setParent($this->ownerItem);
+                }
             }
         }
 
@@ -420,6 +437,7 @@ class Menu implements MenuInterface
         $items = [];
         foreach ($this->items as $item) {
             if ($item->getId() === $id) {
+                $this->clearParentReference($item);
                 continue;
             }
             if ($item->hasSubMenu()) {
@@ -480,6 +498,7 @@ class Menu implements MenuInterface
     {
         foreach ($this->items as $index => $item) {
             if ($item->getKey() === $key) {
+                $this->clearParentReference($item);
                 array_splice($this->items, $index, 1);
 
                 return true;
@@ -667,7 +686,8 @@ class Menu implements MenuInterface
 
     protected function insertItemAt(ItemInterface $item, int $position): void
     {
-        if ($this->ownerItem !== null && !$item->hasParent()) {
+        $this->detachFromCurrentParentIfNeeded($item);
+        if ($this->ownerItem !== null && $item->getParent() !== $this->ownerItem) {
             $item->setParent($this->ownerItem);
         }
         $this->assertUniqueItemTree($item);
@@ -786,6 +806,8 @@ class Menu implements MenuInterface
             }
             if ($callback($item) !== false) {
                 $items[] = $item;
+            } else {
+                $this->clearParentReference($item);
             }
         }
 
@@ -970,6 +992,35 @@ class Menu implements MenuInterface
                 $this->collectIdentifiers($child, $ids);
             }
         }
+    }
+
+    protected function detachFromCurrentParentIfNeeded(ItemInterface $item): void
+    {
+        $parent = $item->getParent();
+        if ($parent === null) {
+            return;
+        }
+        if ($this->ownerItem !== null && $parent === $this->ownerItem) {
+            return;
+        }
+
+        $parent->getSubMenu()->remove($item->getId());
+    }
+
+    protected function clearParentReference(ItemInterface $item): void
+    {
+        if (!$item instanceof Item || $item->getParent() === null) {
+            return;
+        }
+
+        $clearParent = Closure::bind(
+            static function (Item $item): void {
+                $item->parent = null;
+            },
+            null,
+            Item::class,
+        );
+        $clearParent($item);
     }
 
     protected function assertMutable(): void

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -208,6 +208,46 @@ class MenuTest extends TestCase
 
         $this->assertSame($secondParent, $child->getParent());
         $this->assertSame($child, $secondParent->getSubMenu()->get('child'));
+        $this->assertNull($firstParent->getSubMenu()->get('child'));
+    }
+
+    public function testAddMovingItemDetachesItFromOldParent(): void
+    {
+        $menu = Menu::create();
+        $firstParent = $menu->addItem('First', '/first', ['id' => 'first']);
+        $secondParent = $menu->addItem('Second', '/second', ['id' => 'second']);
+        $child = (new Item('Child', '/child'))->setId('child');
+
+        $firstParent->add($child);
+        $secondParent->add($child);
+
+        $this->assertSame($secondParent, $child->getParent());
+        $this->assertNull($firstParent->getSubMenu()->get('child'));
+        $this->assertSame($child, $secondParent->getSubMenu()->get('child'));
+    }
+
+    public function testRemoveClearsParentReference(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '/parent');
+        $child = $parent->getSubMenu()->addItem('Child', '/child', ['id' => 'child']);
+
+        $parent->getSubMenu()->remove('child');
+
+        $this->assertFalse($child->hasParent());
+        $this->assertNull($child->getParent());
+    }
+
+    public function testFilterClearsParentReferenceForRemovedItems(): void
+    {
+        $menu = Menu::create();
+        $parent = $menu->addItem('Parent', '/parent');
+        $child = $parent->getSubMenu()->addItem('Child', '/child', ['id' => 'child']);
+
+        $parent->getSubMenu()->filter(static fn (): bool => false);
+
+        $this->assertFalse($child->hasParent());
+        $this->assertNull($child->getParent());
     }
 
     public function testCollectFlattensTheTree(): void


### PR DESCRIPTION
## Summary
- clear parent pointers when submenu items are removed or filtered out
- detach an item from its old submenu before reparenting it into a new one
- keep Item::add() compatible with move semantics while preserving custom submenu support
- add regression coverage for moving items and for clearing parent references

## Why
The same Item object could end up in two submenus at once: reparenting changed the item's parent, but the old submenu still retained the object. Removed items also kept stale parent references after remove() and filter().

## Validation
- composer test
- composer stan
