### PR TITLE
Fix per-render template overrides leaking across renders

### DIFF
--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -76,11 +76,10 @@ class StringTemplateRenderer implements RendererInterface
      */
     public function render(MenuInterface $menu, array $options = []): string
     {
-        if (isset($options['templates']) && is_array($options['templates'])) {
-            $this->setConfig('templates', array_merge($this->getConfig('templates'), $options['templates']));
-        }
-
-        return $this->renderMenu($menu, $options, 1);
+        return $this->withTemporaryTemplates(
+            $options,
+            fn (): string => $this->renderMenu($menu, $options, 1),
+        );
     }
 
     /**
@@ -88,7 +87,34 @@ class StringTemplateRenderer implements RendererInterface
      */
     public function renderItem(ItemInterface $item, array $options = []): string
     {
-        return $this->renderMenuItem($item, $options, 0, 1, 1);
+        return $this->withTemporaryTemplates(
+            $options,
+            fn (): string => $this->renderMenuItem($item, $options, 0, 1, 1),
+        );
+    }
+
+    /**
+     * Applies per-call template overrides without leaking them into later renders on the same
+     * renderer instance.
+     *
+     * @phpstan-param array<string, mixed> $options
+     * @param callable(): string $callback
+     */
+    protected function withTemporaryTemplates(array $options, callable $callback): string
+    {
+        if (!isset($options['templates']) || !is_array($options['templates'])) {
+            return $callback();
+        }
+
+        /** @var array<string, string> $originalTemplates */
+        $originalTemplates = $this->getTemplates();
+        $this->setTemplates($options['templates']);
+
+        try {
+            return $callback();
+        } finally {
+            $this->setTemplates($originalTemplates);
+        }
     }
 
     /**

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -212,4 +212,35 @@ class StringTemplateRendererTest extends TestCase
         // Nested lists keep their nestedMenuClass and are not given the root class.
         $this->assertStringContainsString('<ul class="submenu">', $result);
     }
+
+    public function testPerRenderTemplatesDoNotLeakAcrossSubsequentRenders(): void
+    {
+        $menu = Menu::create();
+        $menu->addItem('Home', '/');
+        $renderer = new StringTemplateRenderer();
+
+        $custom = $renderer->render($menu, [
+            'templates' => [
+                'link' => '<a data-test="custom"{{attributes}}>{{title}}</a>',
+            ],
+        ]);
+        $default = $renderer->render($menu);
+
+        $this->assertStringContainsString('data-test="custom"', $custom);
+        $this->assertStringNotContainsString('data-test="custom"', $default);
+        $this->assertSame('<ul><li><a href="/">Home</a></li></ul>', $default);
+    }
+
+    public function testRenderItemHonorsPerCallTemplateOverrides(): void
+    {
+        $item = Menu::create()->newItem('Home', '/');
+
+        $result = (new StringTemplateRenderer())->renderItem($item, [
+            'templates' => [
+                'link' => '<a data-test="custom"{{attributes}}>{{title}}</a>',
+            ],
+        ]);
+
+        $this->assertSame('<li><a data-test="custom" href="/">Home</a></li>', $result);
+    }
 }


### PR DESCRIPTION
## Summary
- make template overrides apply only to the current render call
- make renderItem() honor per-call template overrides too
- add regression coverage for override leakage and renderItem() behavior

## Why
StringTemplateRenderer mutates its internal Cake templater when template overrides are passed in render options. Reusing the same renderer instance then leaks those overrides into later renders, and renderItem() ignored the option entirely.

## Validation
- composer test
- composer stan
