### PR TITLE
Honor template overrides in renderItem

### DIFF
--- a/src/Renderer/StringTemplateRenderer.php
+++ b/src/Renderer/StringTemplateRenderer.php
@@ -106,7 +106,19 @@ class StringTemplateRenderer implements RendererInterface
      */
     public function renderItem(ItemInterface $item, array $options = []): string
     {
-        return $this->renderMenuItem($item, $options, 0, 1, 1);
+        $hasOverrides = isset($options['templates']) && is_array($options['templates']) && $options['templates'] !== [];
+        if (!$hasOverrides) {
+            return $this->renderMenuItem($item, $options, 0, 1, 1);
+        }
+
+        $this->templater()->push();
+        try {
+            $this->templater()->add($options['templates']);
+
+            return $this->renderMenuItem($item, $options, 0, 1, 1);
+        } finally {
+            $this->templater()->pop();
+        }
     }
 
     /**

--- a/tests/TestCase/Renderer/BreadcrumbRendererTest.php
+++ b/tests/TestCase/Renderer/BreadcrumbRendererTest.php
@@ -46,4 +46,17 @@ class BreadcrumbRendererTest extends TestCase
 
         $this->assertStringContainsString('<i class="fa fa-home" aria-hidden="true"></i> ', $result);
     }
+
+    public function testRenderItemHonorsPerCallTemplateOverrides(): void
+    {
+        $item = Menu::create()->newItem('Home', '/');
+
+        $result = (new BreadcrumbRenderer())->renderItem($item, [
+            'templates' => [
+                'link' => '<a data-test="custom"{{attributes}}>{{title}}</a>',
+            ],
+        ]);
+
+        $this->assertSame('<li class="breadcrumb-item"><a data-test="custom" href="/">Home</a></li>', $result);
+    }
 }

--- a/tests/TestCase/Renderer/StringTemplateRendererTest.php
+++ b/tests/TestCase/Renderer/StringTemplateRendererTest.php
@@ -212,4 +212,17 @@ class StringTemplateRendererTest extends TestCase
         // Nested lists keep their nestedMenuClass and are not given the root class.
         $this->assertStringContainsString('<ul class="submenu">', $result);
     }
+
+    public function testRenderItemHonorsPerCallTemplateOverrides(): void
+    {
+        $item = Menu::create()->newItem('Home', '/');
+
+        $result = (new StringTemplateRenderer())->renderItem($item, [
+            'templates' => [
+                'link' => '<a data-test="custom"{{attributes}}>{{title}}</a>',
+            ],
+        ]);
+
+        $this->assertSame('<li><a data-test="custom" href="/">Home</a></li>', $result);
+    }
 }


### PR DESCRIPTION
## Summary
- apply per-call `templates` overrides in `StringTemplateRenderer::renderItem()`
- add regression coverage for `StringTemplateRenderer` and `BreadcrumbRenderer`
- keep the same push/pop template isolation used by `render()`

## Why
`RendererInterface::renderItem()` accepts an options array, but on current `master` the `templates` option is ignored for `StringTemplateRenderer` and classes that inherit its implementation, including `BreadcrumbRenderer`.

That means callers can override templates when rendering a whole menu, but not when rendering a single item through the public renderer API.

## Validation
- `composer test`
- `composer stan`
