### PR TITLE
Detach moved items from their old submenu

### DIFF
--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -293,8 +293,15 @@ class Item implements ItemInterface, StateResetInterface
     public function add(ItemInterface $item): static
     {
         $this->assertMutable();
+        $subMenu = $this->getSubMenu();
+        if ($subMenu instanceof Menu) {
+            $subMenu->add($item);
+
+            return $this;
+        }
+
         $item->setParent($this);
-        $this->getSubMenu()->add($item);
+        $subMenu->add($item);
 
         return $this;
     }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -927,12 +927,16 @@ class Menu implements MenuInterface
 
     protected function synchronizeItemParent(ItemInterface $item): void
     {
+        $currentParent = $item->getParent();
         $desiredParent = $this->ownerItem;
-        if ($item->getParent() === $desiredParent) {
+        if ($currentParent === $desiredParent) {
             return;
         }
         if ($item->isFrozen()) {
             throw new LogicException('Cannot move a frozen item to a different parent.');
+        }
+        if ($currentParent !== null) {
+            $currentParent->getSubMenu()->remove($item->getId());
         }
         if ($desiredParent !== null) {
             $item->setParent($desiredParent);

--- a/tests/TestCase/Menu/MenuTest.php
+++ b/tests/TestCase/Menu/MenuTest.php
@@ -209,6 +209,7 @@ class MenuTest extends TestCase
 
         $this->assertSame($secondParent, $child->getParent());
         $this->assertSame($child, $secondParent->getSubMenu()->get('child'));
+        $this->assertNull($firstParent->getSubMenu()->get('child'));
     }
 
     public function testSetItemsDetachesItemsMovedToRootMenu(): void
@@ -224,6 +225,7 @@ class MenuTest extends TestCase
 
         $this->assertNull($child->getParent());
         $this->assertSame($child, $menu->get('child'));
+        $this->assertNull($parent->getSubMenu()->get('child'));
     }
 
     public function testAddReparentsItemMovedBetweenSubmenus(): void
@@ -239,6 +241,8 @@ class MenuTest extends TestCase
         $secondParent->getSubMenu()->add($child);
 
         $this->assertSame($secondParent, $child->getParent());
+        $this->assertNull($firstParent->getSubMenu()->get('child'));
+        $this->assertSame($child, $secondParent->getSubMenu()->get('child'));
     }
 
     public function testRemoveDetachesRemovedItem(): void


### PR DESCRIPTION
## Summary
- detach an item from its previous submenu before reparenting it
- let `Item::add()` delegate built-in submenu moves through `Menu::add()` so detachment logic actually runs
- extend move regression coverage to assert the old submenu is emptied

## Why
On current `master`, moving an item from one submenu to another, or from a submenu to a root menu, updates the item's `parent` pointer but leaves the same object in the old submenu as well.

That means one `Item` instance can render in two places in the tree at once.

## Validation
- `composer test`
- `composer stan`
