### PR TITLE
Fix PHPCS issues after sniffer update

### DIFF
--- a/src/Item/Item.php
+++ b/src/Item/Item.php
@@ -93,7 +93,7 @@ class Item implements ItemInterface, StateResetInterface
      */
     public function __construct(
         ?string $label = null,
-        LinkInterface|string|array|null $link = null,
+        LinkInterface|array|string|null $link = null,
     ) {
         $this->id = 'menu-item-' . Text::uuid();
         if ($label !== null) {
@@ -187,7 +187,7 @@ class Item implements ItemInterface, StateResetInterface
     /**
      * @phpstan-param \Menu\Link\LinkInterface|array<string|int, mixed>|string|null $link
      */
-    public function setLink(LinkInterface|string|array|null $link): static
+    public function setLink(LinkInterface|array|string|null $link): static
     {
         $this->assertMutable();
         if (!$link instanceof LinkInterface) {
@@ -510,7 +510,7 @@ class Item implements ItemInterface, StateResetInterface
     /**
      * @phpstan-param array<string|int, mixed>|string $route
      */
-    public function addMatchRoute(string|array $route): static
+    public function addMatchRoute(array|string $route): static
     {
         $this->assertMutable();
         $this->matchRoutes[] = $route;

--- a/src/Item/ItemInterface.php
+++ b/src/Item/ItemInterface.php
@@ -28,7 +28,7 @@ interface ItemInterface
     /**
      * @phpstan-param \Menu\Link\LinkInterface|array<string|int, mixed>|string|null $link
      */
-    public function setLink(LinkInterface|string|array|null $link): static;
+    public function setLink(LinkInterface|array|string|null $link): static;
 
     public function getLink(): ?LinkInterface;
 
@@ -120,7 +120,7 @@ interface ItemInterface
     /**
      * @phpstan-param array<string|int, mixed>|string $route
      */
-    public function addMatchRoute(string|array $route): static;
+    public function addMatchRoute(array|string $route): static;
 
     /**
      * @phpstan-return list<array<string|int, mixed>|string>

--- a/src/ItemCollection.php
+++ b/src/ItemCollection.php
@@ -85,7 +85,7 @@ class ItemCollection implements Countable, IteratorAggregate
     /**
      * @return list<\Menu\Item\ItemInterface>
      */
-    public function findByParent(string|ItemInterface $parent): array
+    public function findByParent(ItemInterface|string $parent): array
     {
         $parentId = $parent instanceof ItemInterface ? $parent->getId() : $parent;
 

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -33,7 +33,7 @@ class Link implements LinkInterface
      * @phpstan-param array<string, mixed> $attributes
      */
     public static function create(
-        string|array|null $url = null,
+        array|string|null $url = null,
         array $attributes = [],
         bool $external = false,
     ): static {
@@ -51,7 +51,7 @@ class Link implements LinkInterface
      *
      * @throws \LogicException
      */
-    public function setUrl(string|array|null $url, bool $external = false): static
+    public function setUrl(array|string|null $url, bool $external = false): static
     {
         if ($external && is_array($url)) {
             throw new LogicException('External links must use a string URL.');
@@ -91,7 +91,7 @@ class Link implements LinkInterface
     /**
      * @phpstan-return array<string|int, mixed>|string|null
      */
-    public function getRawUrl(): string|array|null
+    public function getRawUrl(): array|string|null
     {
         return $this->url;
     }

--- a/src/Link/LinkInterface.php
+++ b/src/Link/LinkInterface.php
@@ -11,7 +11,7 @@ interface LinkInterface
      * @phpstan-param array<string, mixed> $attributes
      */
     public static function create(
-        string|array|null $url = null,
+        array|string|null $url = null,
         array $attributes = [],
         bool $external = false,
     ): static;
@@ -19,7 +19,7 @@ interface LinkInterface
     /**
      * @phpstan-param array<string|int, mixed>|string|null $url
      */
-    public function setUrl(string|array|null $url, bool $external = false): static;
+    public function setUrl(array|string|null $url, bool $external = false): static;
 
     public function setAttribute(string $name, mixed $value): static;
 
@@ -36,7 +36,7 @@ interface LinkInterface
     /**
      * @phpstan-return array<string|int, mixed>|string|null
      */
-    public function getRawUrl(): string|array|null;
+    public function getRawUrl(): array|string|null;
 
     public function getUrl(): ?string;
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -248,7 +248,7 @@ class Menu implements MenuInterface
      */
     public function addItem(
         string $label,
-        LinkInterface|string|array|null $link = null,
+        LinkInterface|array|string|null $link = null,
         array $options = [],
     ): ItemInterface {
         $item = $this->newItem($label, $link, $options);
@@ -301,7 +301,7 @@ class Menu implements MenuInterface
      */
     public function newItem(
         ?string $label = null,
-        LinkInterface|string|array|null $link = null,
+        LinkInterface|array|string|null $link = null,
         array $options = [],
     ): ItemInterface {
         $className = $this->itemClass;
@@ -664,7 +664,7 @@ class Menu implements MenuInterface
         return $this;
     }
 
-    public function slice(int|string $offset, int|string|null $length = null): static
+    public function slice(string|int $offset, string|int|null $length = null): static
     {
         $start = $this->resolveBoundary($offset);
         if ($length === null) {
@@ -689,7 +689,7 @@ class Menu implements MenuInterface
     /**
      * @phpstan-return array{primary: static, secondary: static}
      */
-    public function split(int|string $length): array
+    public function split(string|int $length): array
     {
         $boundary = $this->resolveBoundary($length);
 
@@ -724,7 +724,7 @@ class Menu implements MenuInterface
      *
      * @throws \InvalidArgumentException When a string id/key is not found.
      */
-    protected function resolveBoundary(int|string $value): int
+    protected function resolveBoundary(string|int $value): int
     {
         if (is_int($value)) {
             return max(0, min($value, count($this->items)));

--- a/src/MenuInterface.php
+++ b/src/MenuInterface.php
@@ -55,7 +55,7 @@ interface MenuInterface
      */
     public function addItem(
         string $label,
-        LinkInterface|string|array|null $link = null,
+        LinkInterface|array|string|null $link = null,
         array $options = [],
     ): ItemInterface;
 
@@ -80,7 +80,7 @@ interface MenuInterface
      */
     public function newItem(
         ?string $label = null,
-        LinkInterface|string|array|null $link = null,
+        LinkInterface|array|string|null $link = null,
         array $options = [],
     ): ItemInterface;
 
@@ -136,12 +136,12 @@ interface MenuInterface
 
     public function merge(MenuInterface $menu, bool $mergeAttributes = false): static;
 
-    public function slice(int|string $offset, int|string|null $length = null): static;
+    public function slice(string|int $offset, string|int|null $length = null): static;
 
     /**
      * @phpstan-return array{primary: static, secondary: static}
      */
-    public function split(int|string $length): array;
+    public function split(string|int $length): array;
 
     public function clearActive(): static;
 


### PR DESCRIPTION
## Summary
- apply PHPCBF fixes for current php-collective/code-sniffer rules
- keep `composer cs-check` green after dependency updates

## Testing
- `composer update --no-interaction --no-progress`
- `composer cs-fix`
- `composer cs-check`